### PR TITLE
Add NormalPostDto's field 'likeReactionId'

### DIFF
--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
@@ -17,7 +17,7 @@ public class NormalPostDto {
     @QueryProjection
     public NormalPostDto(long postId, String title, String content, WriterDto writer,
                          Long commentCount, Long likeReactionCount, Boolean isLiked,
-                         LocalDateTime uploadedAt, LocalDateTime lastModifiedAt) {
+                         Long likeReactionId, LocalDateTime uploadedAt, LocalDateTime lastModifiedAt) {
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -25,6 +25,7 @@ public class NormalPostDto {
         this.commentCount = commentCount;
         this.likeReactionCount = likeReactionCount;
         this.isLiked = isLiked;
+        this.likeReactionId = likeReactionId;
         this.uploadedAt = uploadedAt;
         this.lastModifiedAt = lastModifiedAt;
     }
@@ -43,8 +44,10 @@ public class NormalPostDto {
     @JsonInclude(NON_NULL)
     private Long likeReactionCount;
 
-    @JsonInclude(NON_NULL)
     private Boolean isLiked;
+
+    @JsonInclude(NON_NULL)
+    private Long likeReactionId;
 
     private LocalDateTime uploadedAt;
 

--- a/src/main/java/com/honeypot/domain/post/repository/QuerydslRepositoryImpl.java
+++ b/src/main/java/com/honeypot/domain/post/repository/QuerydslRepositoryImpl.java
@@ -53,9 +53,17 @@ public class QuerydslRepositoryImpl {
                                                 .where(reaction.postId.eq(post.id)
                                                         .and(reaction.reactionType.eq(ReactionType.LIKE))
                                                         .and(reaction.reactor.id.eq(memberId))
-                                                        )
+                                                )
                                                 .exists(),
                                         "isLiked"),
+                                ExpressionUtils.as(
+                                        select(reaction.id)
+                                                .from(reaction)
+                                                .where(reaction.postId.eq(post.id)
+                                                        .and(reaction.reactionType.eq(ReactionType.LIKE))
+                                                        .and(reaction.reactor.id.eq(memberId))
+                                                ),
+                                        "likeReactionId"),
                                 post.createdAt,
                                 post.lastModifiedAt
                         )

--- a/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
+++ b/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
@@ -65,6 +65,7 @@ public class NormalPostService {
         result.setCommentCount(commentRepository.countByPostId(postId));
         if (memberId != null) {
             result.setIsLiked(reactionRepository.isLikePost(postId, memberId));
+            result.setLikeReactionId(reactionRepository.findIdByLikePostId(postId, memberId));
         } else {
             result.setIsLiked(false);
         }

--- a/src/main/java/com/honeypot/domain/reaction/repository/ReactionRepository.java
+++ b/src/main/java/com/honeypot/domain/reaction/repository/ReactionRepository.java
@@ -27,4 +27,12 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
             nativeQuery = true)
     boolean isLikePost(Long postId, Long memberId);
 
+    @Query(value = "SELECT r.reaction_id " +
+            "FROM reaction r " +
+            "WHERE r.reaction_type = 'LIKE' " +
+            "AND member_id = :memberId " +
+            "AND post_id = :postId",
+            nativeQuery = true)
+    Long findIdByLikePostId(Long postId, Long memberId);
+
 }


### PR DESCRIPTION
### What's Changed?
- 리액션 취소를 위한 `reactionId`를 클라이언트에 알려주기 위해 `NormalPostDto`에 `likeReactionId` 필드 추가

### Related Issue
- resolved: #35 