### PR TITLE
게시글 작성 API 고도화  (파일 첨부, 리액션 관련 API 필드 추가, 버그 수정, HTTPS 적용)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ hs_err_pid*
 
 # Build outputs
 build
+bin
 
 # Gradle
 .gradle
+
+# Keystore
+keystore

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ bin
 
 # Keystore
 keystore
+
+# AWS
+application*.yml
+aws.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // Spring cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
     annotationProcessor(
@@ -79,6 +82,7 @@ tasks.named("jar") {
 
 tasks.named("bootRun") {
     mainClass = 'com.honeypot.HoneyPotApplication'
+    jvmArgs = ["-Dcom.amazonaws.sdk.disableEc2Metadata=true"]
 }
 
 tasks.named("bootJar") {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.honeypot'
-version '0.0.5'
+version '0.0.6'
 sourceCompatibility = '17'
 
 repositories {

--- a/src/main/java/com/honeypot/common/config/WebConfig.java
+++ b/src/main/java/com/honeypot/common/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.honeypot.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -13,7 +14,17 @@ public class WebConfig implements WebMvcConfigurer {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**").allowedOrigins("*");
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods(
+                                HttpMethod.GET.name(),
+                                HttpMethod.POST.name(),
+                                HttpMethod.PUT.name(),
+                                HttpMethod.DELETE.name(),
+                                HttpMethod.HEAD.name(),
+                                HttpMethod.PATCH.name(),
+                                HttpMethod.OPTIONS.name()
+                        );
             }
         };
     }

--- a/src/main/java/com/honeypot/domain/file/AttachedFileResponse.java
+++ b/src/main/java/com/honeypot/domain/file/AttachedFileResponse.java
@@ -1,0 +1,14 @@
+package com.honeypot.domain.file;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AttachedFileResponse {
+
+    private Long fileId;
+
+    private String fileLocationUrl;
+
+}

--- a/src/main/java/com/honeypot/domain/file/File.java
+++ b/src/main/java/com/honeypot/domain/file/File.java
@@ -1,0 +1,41 @@
+package com.honeypot.domain.file;
+
+import com.honeypot.common.entity.BaseTimeEntity;
+import com.honeypot.domain.post.entity.Post;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@SuperBuilder
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class File extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "file_id")
+    private Long id;
+
+    @Column(name = "filename", nullable = false)
+    private String filename;
+
+    @Column(name = "original_filename")
+    private String originalFilename;
+
+    @Column(name = "file_path", nullable = false)
+    private String filePath;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "file_type")
+    private FileType fileType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+}

--- a/src/main/java/com/honeypot/domain/file/FileApi.java
+++ b/src/main/java/com/honeypot/domain/file/FileApi.java
@@ -1,0 +1,27 @@
+package com.honeypot.domain.file;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/files")
+@RestController
+public class FileApi {
+
+    private final FileUploadService fileUploadService;
+
+    @GetMapping("/presigned-url")
+    public ResponseEntity<?> getPresignedUrl(@Valid FileUploadRequest fileUploadRequest) {
+        FileDto fileDto = fileUploadService.upload(fileUploadRequest);
+
+        return ResponseEntity.ok(fileDto);
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/file/FileDto.java
+++ b/src/main/java/com/honeypot/domain/file/FileDto.java
@@ -1,0 +1,27 @@
+package com.honeypot.domain.file;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+public class FileDto {
+
+    private Long fileId;
+
+    @NotNull
+    private String filename;
+
+    private String originalFilename;
+
+    @NotNull
+    private String filePath;
+
+    @NotNull
+    private FileType fileType;
+
+    private String presignedUrl;
+
+}

--- a/src/main/java/com/honeypot/domain/file/FileMapper.java
+++ b/src/main/java/com/honeypot/domain/file/FileMapper.java
@@ -1,0 +1,25 @@
+package com.honeypot.domain.file;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+// TODO write test code
+@Mapper(componentModel = "spring")
+public interface FileMapper {
+
+    @Mapping(target = "post", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "lastModifiedAt", ignore = true)
+    @Mapping(target = "id", source = "fileId")
+    @Mapping(target = "filename", source = "filename")
+    @Mapping(target = "originalFilename", source = "originalFilename")
+    @Mapping(target = "filePath", source = "filePath")
+    @Mapping(target = "fileType", source = "fileType")
+    File toEntity(FileDto dto);
+
+    @Mapping(target = "presignedUrl", ignore = true)
+    @InheritInverseConfiguration
+    FileDto toDto(File entity);
+
+}

--- a/src/main/java/com/honeypot/domain/file/FileRepository.java
+++ b/src/main/java/com/honeypot/domain/file/FileRepository.java
@@ -1,0 +1,8 @@
+package com.honeypot.domain.file;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FileRepository extends JpaRepository<File, Long> {
+}

--- a/src/main/java/com/honeypot/domain/file/FileType.java
+++ b/src/main/java/com/honeypot/domain/file/FileType.java
@@ -1,0 +1,18 @@
+package com.honeypot.domain.file;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public enum FileType {
+
+    NORMAL_POST_IMAGE("img/normal-posts/", List.of("jpg", "jpeg", "png")),
+
+    USED_TRADE_POST_IMAGE("img/used-trades/", List.of("jpg", "jpeg", "png"));
+
+    public final String fileDirectory;
+
+    public final List<String> allowedExtension;
+
+}

--- a/src/main/java/com/honeypot/domain/file/FileUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/file/FileUploadRequest.java
@@ -1,0 +1,18 @@
+package com.honeypot.domain.file;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+public class FileUploadRequest {
+
+    @NotNull
+    private String filename;
+
+    @NotNull
+    private FileType fileType;
+
+}

--- a/src/main/java/com/honeypot/domain/file/FileUploadService.java
+++ b/src/main/java/com/honeypot/domain/file/FileUploadService.java
@@ -1,0 +1,106 @@
+package com.honeypot.domain.file;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.honeypot.common.validation.groups.InsertContext;
+import com.honeypot.domain.post.entity.Post;
+import com.honeypot.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.persistence.EntityNotFoundException;
+import javax.validation.Valid;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Validated
+public class FileUploadService {
+
+    private final FileMapper fileMapper;
+
+    private final FileRepository fileRepository;
+
+    private final PostRepository postRepository;
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.s3.domain}")
+    private String s3Domain;
+
+    @Value("${cloud.aws.presigned-url.expiration-time-in-seconds}")
+    private long presignedUrlExpirationTimeInSecond;
+
+    @Transactional
+    public FileDto upload(FileUploadRequest file) {
+        // TODO check file extension
+
+        String newFileName = generateUniqueFileName(file.getFilename());
+
+        FileDto fileDto = FileDto.builder()
+                .filename(newFileName)
+                .originalFilename(file.getFilename())
+                .filePath(file.getFileType().fileDirectory + newFileName)
+                .fileType(file.getFileType())
+                .build();
+
+        File uploaded = fileRepository.save(fileMapper.toEntity(fileDto));
+        FileDto result = fileMapper.toDto(uploaded);
+
+        // generate presigned url
+        result.setPresignedUrl(generatePresignedUrl(result.getFilePath()));
+
+        return result;
+    }
+
+    @Transactional
+    @Validated(InsertContext.class)
+    public AttachedFileResponse linkFileWithPost(@Valid PostFileUploadRequest request) {
+        Long fileId = request.getFileId();
+
+        File uploaded = fileRepository.findById(fileId).orElseThrow(EntityNotFoundException::new);
+        Post linkPost = postRepository.findById(request.getLinkPostId()).orElseThrow(EntityNotFoundException::new);
+
+        uploaded.setPost(linkPost);
+
+        return AttachedFileResponse.builder()
+                .fileId(fileId)
+                .fileLocationUrl(s3Domain+uploaded.getFilePath())
+                .build();
+    }
+
+    private String generateUniqueFileName(String filename) {
+        // TODO change unique name generation strategy
+        return LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) + "_" + filename;
+    }
+
+
+    private String generatePresignedUrl(String filePath) {
+        GeneratePresignedUrlRequest preSignedUrlRequest
+                = new GeneratePresignedUrlRequest(bucketName, filePath)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(new Date(System.currentTimeMillis() +
+                        presignedUrlExpirationTimeInSecond * 1000));
+
+        preSignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL,
+                CannedAccessControlList.PublicRead.toString()
+        );
+
+        return amazonS3Client.generatePresignedUrl(preSignedUrlRequest).toExternalForm();
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/file/PostFileUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/file/PostFileUploadRequest.java
@@ -1,0 +1,20 @@
+package com.honeypot.domain.file;
+
+import com.honeypot.common.validation.groups.InsertContext;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class PostFileUploadRequest {
+
+    @NotNull
+    private Long fileId;
+
+    @NotNull
+    private boolean willBeUploaded;
+
+    @NotNull(groups = InsertContext.class)
+    private Long linkPostId;
+
+}

--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
@@ -1,17 +1,21 @@
 package com.honeypot.domain.post.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.honeypot.domain.file.AttachedFileResponse;
 import com.honeypot.domain.member.dto.WriterDto;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
 @Builder
+@AllArgsConstructor
 public class NormalPostDto {
 
     @QueryProjection
@@ -48,6 +52,9 @@ public class NormalPostDto {
 
     @JsonInclude(NON_NULL)
     private Long likeReactionId;
+
+    @JsonInclude(NON_NULL)
+    private List<AttachedFileResponse> attachedFiles;
 
     private LocalDateTime uploadedAt;
 

--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
@@ -17,7 +17,7 @@ public class NormalPostDto {
     @QueryProjection
     public NormalPostDto(long postId, String title, String content, WriterDto writer,
                          Long commentCount, Long likeReactionCount, Boolean isLiked,
-                         LocalDateTime uploadedAt, LocalDateTime lastModifiedAt) {
+                         Long likeReactionId, LocalDateTime uploadedAt, LocalDateTime lastModifiedAt) {
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -25,6 +25,7 @@ public class NormalPostDto {
         this.commentCount = commentCount;
         this.likeReactionCount = likeReactionCount;
         this.isLiked = isLiked;
+        this.likeReactionId = likeReactionId;
         this.uploadedAt = uploadedAt;
         this.lastModifiedAt = lastModifiedAt;
     }
@@ -43,8 +44,10 @@ public class NormalPostDto {
     @JsonInclude(NON_NULL)
     private Long likeReactionCount;
 
-    @JsonInclude(NON_NULL)
     private Boolean isLiked;
+
+    @JsonInclude(NON_NULL)
+    private Long likeReactionId;
 
     private LocalDateTime uploadedAt;
 

--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostUploadRequest.java
@@ -1,12 +1,14 @@
 package com.honeypot.domain.post.dto;
 
 import com.honeypot.common.validation.groups.InsertContext;
+import com.honeypot.domain.file.PostFileUploadRequest;
 import lombok.Builder;
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Data
 @Builder
@@ -21,4 +23,7 @@ public class NormalPostUploadRequest {
 
     @NotNull(groups = InsertContext.class)
     private Long writerId;
+
+    List<PostFileUploadRequest> attachedFiles;
+
 }

--- a/src/main/java/com/honeypot/domain/post/repository/QuerydslRepositoryImpl.java
+++ b/src/main/java/com/honeypot/domain/post/repository/QuerydslRepositoryImpl.java
@@ -40,13 +40,13 @@ public class QuerydslRepositoryImpl {
                                         post.writer.id,
                                         post.writer.nickname
                                 ),
+                                post.comments.size().castToNum(Long.class),
                                 ExpressionUtils.as(
                                         select(reaction.count())
                                                 .from(reaction)
                                                 .where(reaction.postId.eq(post.id)
                                                         .and(reaction.reactionType.eq(ReactionType.LIKE))),
                                         "likeReactionCount"),
-                                post.comments.size().castToNum(Long.class),
                                 ExpressionUtils.as(
                                         select(selectOne())
                                                 .from(reaction)

--- a/src/main/java/com/honeypot/domain/post/repository/QuerydslRepositoryImpl.java
+++ b/src/main/java/com/honeypot/domain/post/repository/QuerydslRepositoryImpl.java
@@ -53,9 +53,17 @@ public class QuerydslRepositoryImpl {
                                                 .where(reaction.postId.eq(post.id)
                                                         .and(reaction.reactionType.eq(ReactionType.LIKE))
                                                         .and(reaction.reactor.id.eq(memberId))
-                                                        )
+                                                )
                                                 .exists(),
                                         "isLiked"),
+                                ExpressionUtils.as(
+                                        select(reaction.id)
+                                                .from(reaction)
+                                                .where(reaction.postId.eq(post.id)
+                                                        .and(reaction.reactionType.eq(ReactionType.LIKE))
+                                                        .and(reaction.reactor.id.eq(memberId))
+                                                ),
+                                        "likeReactionId"),
                                 post.createdAt,
                                 post.lastModifiedAt
                         )

--- a/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
+++ b/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
@@ -65,6 +65,7 @@ public class NormalPostService {
         result.setCommentCount(commentRepository.countByPostId(postId));
         if (memberId != null) {
             result.setIsLiked(reactionRepository.isLikePost(postId, memberId));
+            result.setLikeReactionId(reactionRepository.findIdByLikePostId(postId, memberId));
         } else {
             result.setIsLiked(false);
         }

--- a/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
+++ b/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
@@ -1,14 +1,15 @@
 package com.honeypot.domain.post.service;
 
 import com.honeypot.common.model.exceptions.InvalidAuthorizationException;
-import com.honeypot.common.model.exceptions.InvalidTokenException;
-import com.honeypot.common.utils.SecurityUtils;
 import com.honeypot.common.validation.groups.InsertContext;
 import com.honeypot.domain.comment.repository.CommentRepository;
+import com.honeypot.domain.file.AttachedFileResponse;
+import com.honeypot.domain.file.FileUploadService;
 import com.honeypot.domain.member.entity.Member;
 import com.honeypot.domain.member.repository.MemberRepository;
 import com.honeypot.domain.post.dto.NormalPostDto;
 import com.honeypot.domain.post.dto.NormalPostUploadRequest;
+import com.honeypot.domain.file.PostFileUploadRequest;
 import com.honeypot.domain.post.entity.NormalPost;
 import com.honeypot.domain.post.mapper.NormalPostMapper;
 import com.honeypot.domain.post.repository.NormalPostRepository;
@@ -26,6 +27,7 @@ import org.springframework.validation.annotation.Validated;
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +45,8 @@ public class NormalPostService {
     private final CommentRepository commentRepository;
 
     private final MemberRepository memberRepository;
+
+    private final FileUploadService fileUploadService;
 
     @Transactional(readOnly = true)
     public Page<NormalPostDto> pageList(Pageable pageable, Long memberId) {
@@ -85,6 +89,17 @@ public class NormalPostService {
 
         NormalPostDto result = normalPostMapper.toDto(created);
         result.getWriter().setNickname(writer.getNickname());
+
+        List<PostFileUploadRequest> attachedFiles = request.getAttachedFiles();
+        if (attachedFiles != null) {
+            List<AttachedFileResponse> files = attachedFiles.stream()
+                    .filter(PostFileUploadRequest::isWillBeUploaded)
+                    .peek(f -> f.setLinkPostId(result.getPostId()))
+                    .map(fileUploadService::linkFileWithPost)
+                    .toList();
+
+            result.setAttachedFiles(files);
+        }
 
         return result;
     }

--- a/src/main/java/com/honeypot/domain/reaction/repository/ReactionRepository.java
+++ b/src/main/java/com/honeypot/domain/reaction/repository/ReactionRepository.java
@@ -27,4 +27,12 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
             nativeQuery = true)
     boolean isLikePost(Long postId, Long memberId);
 
+    @Query(value = "SELECT r.reaction_id " +
+            "FROM reaction r " +
+            "WHERE r.reaction_type = 'LIKE' " +
+            "AND member_id = :memberId " +
+            "AND post_id = :postId",
+            nativeQuery = true)
+    Long findIdByLikePostId(Long postId, Long memberId);
+
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -58,7 +58,7 @@ logging:
 oauth:
   kakao:
     client-secret: lDDWMiLlahtpdtKCgR04mlUCFvGsXbhV
-    redirect-url: "http://localhost:8090/api/auth/kakao"
+    redirect-url: "https://localhost:8090/api/auth/kakao"
     api-key:
       rest-api: 211dafc4f98802b4890c43ec2b305f72
       admin: 3a032aeb8d68e14d7d99c7172142911a

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,12 @@ server:
   port: 8090
   servlet:
     context-path: /
+  ssl:
+    key-store: ./keystore/honeypots-keystore.pkcs12
+    key-store-type: PKCS12
+    key-store-password: honeypot
+    key-alias: honeypots-keystore
+
 
 # Spring settings
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ server:
 spring:
   profiles:
     active: dev
+    include:
+      - aws
 
   # Datasource
   datasource:

--- a/src/test/java/com/honeypot/domain/file/FileMapperTest.java
+++ b/src/test/java/com/honeypot/domain/file/FileMapperTest.java
@@ -1,0 +1,69 @@
+package com.honeypot.domain.file;
+
+import com.honeypot.domain.post.entity.Post;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FileMapperTest {
+
+    private final FileMapper mapper = Mappers.getMapper(FileMapper.class);
+
+
+    @Test
+    void toEntity() {
+        // Arrange
+        FileDto dto = FileDto.builder()
+                .fileId(1L)
+                .filename("filename")
+                .originalFilename("originalFilename")
+                .filePath("img/test/filepath")
+                .fileType(FileType.NORMAL_POST_IMAGE)
+                .presignedUrl("presignedUrl")
+                .build();
+
+        // Act
+        File entity = mapper.toEntity(dto);
+
+        // Assert
+        assertEquals(dto.getFileId(), entity.getId());
+        assertEquals(dto.getFilename(), entity.getFilename());
+        assertEquals(dto.getOriginalFilename(), entity.getOriginalFilename());
+        assertEquals(dto.getFilePath(), entity.getFilePath());
+        assertEquals(dto.getFileType(), entity.getFileType());
+    }
+
+    @Test
+    void toDto() {
+        // Arrange
+        LocalDateTime uploadedAt = LocalDateTime.of(2022, 7, 28, 22, 0, 0);
+        File entity = File.builder()
+                .id(1L)
+                .filename("filename")
+                .originalFilename("originalFilename")
+                .filePath("filePath")
+                .fileType(FileType.NORMAL_POST_IMAGE)
+                .post(Post.builder()
+                        .id(2L)
+                        .build())
+                .createdAt(uploadedAt)
+                .lastModifiedAt(uploadedAt)
+                .build();
+
+        // Act
+        FileDto dto = mapper.toDto(entity);
+
+        // Assert
+        assertEquals(entity.getId(), dto.getFileId());
+        assertEquals(entity.getFilename(), dto.getFilename());
+        assertEquals(entity.getOriginalFilename(), dto.getOriginalFilename());
+        assertEquals(entity.getFilePath(), dto.getFilePath());
+        assertEquals(entity.getFileType(), dto.getFileType());
+        assertNull(dto.getPresignedUrl());
+    }
+
+}


### PR DESCRIPTION
### What's Changed?
- 게시글 조회 시 `ReactionId` 반환 #37
- 게시글 조회 응답 Dto 필드 매핑 순서 오류 수정 #38
- HTTPS 적용 #40
- 게시글 작성 시 파일 업로드 #41 

### Versioning
- version bump from **0.0.5** to **0.0.6**