### PR TITLE
Feature/used trade post api

### DIFF
--- a/src/main/java/com/honeypot/common/validation/constraints/Enum.java
+++ b/src/main/java/com/honeypot/common/validation/constraints/Enum.java
@@ -29,6 +29,8 @@ public @interface Enum {
 
     Class<? extends java.lang.Enum<?>> target();
 
+    boolean ifNull() default false;
+
     @Documented
     @Target(FIELD)
     @Retention(RUNTIME)

--- a/src/main/java/com/honeypot/common/validation/validators/EnumValidator.java
+++ b/src/main/java/com/honeypot/common/validation/validators/EnumValidator.java
@@ -11,17 +11,21 @@ import java.util.stream.Stream;
 public class EnumValidator implements ConstraintValidator<Enum, CharSequence> {
     private Set<String> enumValues;
 
+    private boolean validIfNull;
+
     @Override
     public void initialize(Enum constraintAnnotation) {
         enumValues = Stream.of(constraintAnnotation.target().getEnumConstants())
                 .map(java.lang.Enum::name)
                 .collect(Collectors.toSet());
+
+        validIfNull = constraintAnnotation.ifNull();
     }
 
     @Override
     public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
         if (value == null) {
-            return false;
+            return validIfNull;
         }
         return enumValues.contains(value.toString().toUpperCase());
     }

--- a/src/main/java/com/honeypot/domain/post/api/UsedTradePostApi.java
+++ b/src/main/java/com/honeypot/domain/post/api/UsedTradePostApi.java
@@ -3,6 +3,7 @@ package com.honeypot.domain.post.api;
 import com.honeypot.common.model.exceptions.InvalidTokenException;
 import com.honeypot.common.utils.SecurityUtils;
 import com.honeypot.common.validation.constraints.AllowedSortProperties;
+import com.honeypot.domain.post.dto.UsedTradeModifyRequest;
 import com.honeypot.domain.post.dto.UsedTradePostDto;
 import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
 import com.honeypot.domain.post.service.UsedTradePostService;
@@ -58,6 +59,18 @@ public class UsedTradePostApi {
         Long memberId = SecurityUtils.getCurrentMemberId().orElseThrow(InvalidTokenException::new);
         uploadRequest.setWriterId(memberId);
         UsedTradePostDto uploadedPost = usedTradePostService.update(postId, uploadRequest);
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<?> updateTradeStatus(@PathVariable long postId,
+                                               @Valid @RequestBody UsedTradeModifyRequest request) {
+        Long memberId = SecurityUtils.getCurrentMemberId().orElseThrow(InvalidTokenException::new);
+        request.setWriterId(memberId);
+        UsedTradePostDto updated = usedTradePostService.updateTradeStatus(postId, request);
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/com/honeypot/domain/post/api/UsedTradePostApi.java
+++ b/src/main/java/com/honeypot/domain/post/api/UsedTradePostApi.java
@@ -1,0 +1,77 @@
+package com.honeypot.domain.post.api;
+
+import com.honeypot.common.model.exceptions.InvalidTokenException;
+import com.honeypot.common.utils.SecurityUtils;
+import com.honeypot.common.validation.constraints.AllowedSortProperties;
+import com.honeypot.domain.post.dto.UsedTradePostDto;
+import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
+import com.honeypot.domain.post.service.UsedTradePostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/posts/used-trades")
+@RequiredArgsConstructor
+@Validated
+public class UsedTradePostApi {
+
+    private final UsedTradePostService usedTradePostService;
+
+    @GetMapping
+    public ResponseEntity<?> pageList(@AllowedSortProperties("createdAt") Pageable pageable) {
+        Long memberId = SecurityUtils.getCurrentMemberId().orElse(null);
+        return ResponseEntity.ok(usedTradePostService.pageList(pageable, memberId));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<?> read(@PathVariable long postId) {
+        Long memberId = SecurityUtils.getCurrentMemberId().orElse(null);
+        return ResponseEntity.ok(usedTradePostService.find(postId, memberId));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> upload(@Valid @RequestBody UsedTradePostUploadRequest uploadRequest) {
+        Long memberId = SecurityUtils.getCurrentMemberId().orElseThrow(InvalidTokenException::new);
+        uploadRequest.setWriterId(memberId);
+
+        UsedTradePostDto uploadedPost = usedTradePostService.upload(uploadRequest);
+
+        return ResponseEntity
+                .created(ServletUriComponentsBuilder
+                        .fromCurrentRequest()
+                        .path("/{postId}")
+                        .buildAndExpand(uploadedPost.getPostId())
+                        .toUri())
+                .body(uploadedPost);
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<?> update(@PathVariable long postId,
+                                    @Valid @RequestBody UsedTradePostUploadRequest uploadRequest) {
+
+        Long memberId = SecurityUtils.getCurrentMemberId().orElseThrow(InvalidTokenException::new);
+        uploadRequest.setWriterId(memberId);
+        UsedTradePostDto uploadedPost = usedTradePostService.update(postId, uploadRequest);
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<?> delete(@PathVariable long postId) {
+        Long memberId = SecurityUtils.getCurrentMemberId().orElseThrow(InvalidTokenException::new);
+        usedTradePostService.delete(postId, memberId);
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
@@ -50,6 +50,7 @@ public class NormalPostDto {
     @JsonInclude(NON_NULL)
     private Long likeReactionCount;
 
+    @JsonInclude(NON_NULL)
     private Boolean isLiked;
 
     @JsonInclude(NON_NULL)

--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostDto.java
@@ -5,8 +5,8 @@ import com.honeypot.domain.file.AttachedFileResponse;
 import com.honeypot.domain.member.dto.WriterDto;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.List;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 public class NormalPostDto {
 

--- a/src/main/java/com/honeypot/domain/post/dto/NormalPostUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/post/dto/NormalPostUploadRequest.java
@@ -2,8 +2,10 @@ package com.honeypot.domain.post.dto;
 
 import com.honeypot.common.validation.groups.InsertContext;
 import com.honeypot.domain.file.PostFileUploadRequest;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
@@ -11,7 +13,9 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
-@Builder
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 public class NormalPostUploadRequest {
 
     @Length(max = 30)

--- a/src/main/java/com/honeypot/domain/post/dto/UsedTradeModifyRequest.java
+++ b/src/main/java/com/honeypot/domain/post/dto/UsedTradeModifyRequest.java
@@ -1,0 +1,23 @@
+package com.honeypot.domain.post.dto;
+
+import com.honeypot.common.validation.constraints.Enum;
+import com.honeypot.common.validation.groups.InsertContext;
+import com.honeypot.domain.post.entity.enums.TradeStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@ToString
+public class UsedTradeModifyRequest {
+
+    @Enum(target = TradeStatus.class)
+    private String tradeStatus;
+
+    @NotNull(groups = InsertContext.class)
+    private Long writerId;
+
+}

--- a/src/main/java/com/honeypot/domain/post/dto/UsedTradePostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/UsedTradePostDto.java
@@ -1,17 +1,36 @@
 package com.honeypot.domain.post.dto;
 
+import com.honeypot.domain.file.AttachedFileResponse;
+import com.honeypot.domain.member.dto.WriterDto;
 import com.honeypot.domain.post.entity.enums.TradeStatus;
 import com.honeypot.domain.post.entity.enums.TradeType;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
+import java.time.LocalDateTime;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 @SuperBuilder
 public class UsedTradePostDto extends NormalPostDto {
+
+    @QueryProjection
+    public UsedTradePostDto(long postId, String title, String content, WriterDto writer,
+                            Long commentCount, Long likeReactionCount, Boolean isLiked,
+                            Long likeReactionId, AttachedFileResponse thumbnailImageFile,
+                            LocalDateTime uploadedAt, LocalDateTime lastModifiedAt,
+                            int goodsPrice, TradeType tradeType, TradeStatus tradeStatus,
+                            String chatRoomLink) {
+        super(postId, title, content, writer, commentCount, likeReactionCount, isLiked,
+                likeReactionId, thumbnailImageFile, uploadedAt, lastModifiedAt);
+        this.goodsPrice = goodsPrice;
+        this.tradeType = tradeType;
+        this.tradeStatus = tradeStatus;
+        this.chatRoomLink = chatRoomLink;
+    }
 
     @PositiveOrZero
     private int goodsPrice;

--- a/src/main/java/com/honeypot/domain/post/dto/UsedTradePostDto.java
+++ b/src/main/java/com/honeypot/domain/post/dto/UsedTradePostDto.java
@@ -1,0 +1,27 @@
+package com.honeypot.domain.post.dto;
+
+import com.honeypot.domain.post.entity.enums.TradeStatus;
+import com.honeypot.domain.post.entity.enums.TradeType;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@SuperBuilder
+public class UsedTradePostDto extends NormalPostDto {
+
+    @PositiveOrZero
+    private int goodsPrice;
+
+    @NotNull
+    private TradeType tradeType;
+
+    @NotNull
+    private TradeStatus tradeStatus;
+
+    private String chatRoomLink;
+
+}

--- a/src/main/java/com/honeypot/domain/post/dto/UsedTradePostUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/post/dto/UsedTradePostUploadRequest.java
@@ -1,10 +1,13 @@
 package com.honeypot.domain.post.dto;
 
 import com.honeypot.common.validation.constraints.Enum;
+import com.honeypot.common.validation.groups.InsertContext;
+import com.honeypot.domain.post.entity.enums.TradeStatus;
 import com.honeypot.domain.post.entity.enums.TradeType;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 
 @EqualsAndHashCode(callSuper = false)
@@ -17,8 +20,11 @@ public class UsedTradePostUploadRequest extends NormalPostUploadRequest {
     @PositiveOrZero
     private int goodsPrice;
 
-    @Enum(target = TradeType.class)
+    @Enum(target = TradeType.class, groups = InsertContext.class)
     private String tradeType;
+
+    @Enum(target = TradeStatus.class, ifNull = true, groups = InsertContext.class)
+    private String tradeStatus;
 
     private String chatRoomLink;
 

--- a/src/main/java/com/honeypot/domain/post/dto/UsedTradePostUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/post/dto/UsedTradePostUploadRequest.java
@@ -1,0 +1,25 @@
+package com.honeypot.domain.post.dto;
+
+import com.honeypot.common.validation.constraints.Enum;
+import com.honeypot.domain.post.entity.enums.TradeType;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.PositiveOrZero;
+
+@EqualsAndHashCode(callSuper = false)
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsedTradePostUploadRequest extends NormalPostUploadRequest {
+
+    @PositiveOrZero
+    private int goodsPrice;
+
+    @Enum(target = TradeType.class)
+    private String tradeType;
+
+    private String chatRoomLink;
+
+}

--- a/src/main/java/com/honeypot/domain/post/entity/NormalPost.java
+++ b/src/main/java/com/honeypot/domain/post/entity/NormalPost.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -14,6 +15,7 @@ import javax.persistence.Entity;
 @DiscriminatorValue("NORMAL")
 @SuperBuilder
 @NoArgsConstructor
+@DynamicUpdate
 public class NormalPost extends Post {
 
 }

--- a/src/main/java/com/honeypot/domain/post/entity/Post.java
+++ b/src/main/java/com/honeypot/domain/post/entity/Post.java
@@ -5,6 +5,7 @@ import com.honeypot.domain.comment.entity.Comment;
 import com.honeypot.domain.member.entity.Member;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import java.util.List;
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "type", length = 10)
 @NoArgsConstructor
+@DynamicUpdate
 public class Post extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
+++ b/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
@@ -15,6 +16,7 @@ import javax.persistence.*;
 @SuperBuilder
 @NoArgsConstructor
 @DiscriminatorValue("USED_TRADE")
+@DynamicUpdate
 public class UsedTradePost extends Post {
 
     @Column(name = "goods_price")

--- a/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
+++ b/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
@@ -4,13 +4,13 @@ import com.honeypot.domain.post.entity.enums.TradeStatus;
 import com.honeypot.domain.post.entity.enums.TradeType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
+import javax.persistence.*;
 
 @Getter
+@Setter
 @Entity
 @SuperBuilder
 @NoArgsConstructor
@@ -23,9 +23,11 @@ public class UsedTradePost extends Post {
     @Column(name = "chat_room_link")
     private String chatRoomLink;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "trade_type")
     private TradeType tradeType;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "trade_status")
     private TradeStatus tradeStatus;
 

--- a/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
+++ b/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
@@ -3,6 +3,8 @@ package com.honeypot.domain.post.entity;
 import com.honeypot.domain.post.entity.enums.TradeStatus;
 import com.honeypot.domain.post.entity.enums.TradeType;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
@@ -10,6 +12,8 @@ import javax.persistence.Entity;
 
 @Getter
 @Entity
+@SuperBuilder
+@NoArgsConstructor
 @DiscriminatorValue("USED_TRADE")
 public class UsedTradePost extends Post {
 

--- a/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
+++ b/src/main/java/com/honeypot/domain/post/entity/UsedTradePost.java
@@ -1,5 +1,7 @@
 package com.honeypot.domain.post.entity;
 
+import com.honeypot.domain.post.entity.enums.TradeStatus;
+import com.honeypot.domain.post.entity.enums.TradeType;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -18,12 +20,9 @@ public class UsedTradePost extends Post {
     private String chatRoomLink;
 
     @Column(name = "trade_type")
-    private String tradeType;
-
-    @Column(name = "trade_area")
-    private String tradeArea;
+    private TradeType tradeType;
 
     @Column(name = "trade_status")
-    private String tradeStatus;
+    private TradeStatus tradeStatus;
 
 }

--- a/src/main/java/com/honeypot/domain/post/entity/enums/TradeStatus.java
+++ b/src/main/java/com/honeypot/domain/post/entity/enums/TradeStatus.java
@@ -1,0 +1,5 @@
+package com.honeypot.domain.post.entity.enums;
+
+public enum TradeStatus {
+    ONGOING, HOLD, COMPLETE
+}

--- a/src/main/java/com/honeypot/domain/post/entity/enums/TradeType.java
+++ b/src/main/java/com/honeypot/domain/post/entity/enums/TradeType.java
@@ -1,0 +1,5 @@
+package com.honeypot.domain.post.entity.enums;
+
+public enum TradeType {
+    BUY, SELL
+}

--- a/src/main/java/com/honeypot/domain/post/mapper/UsedTradePostMapper.java
+++ b/src/main/java/com/honeypot/domain/post/mapper/UsedTradePostMapper.java
@@ -1,0 +1,43 @@
+package com.honeypot.domain.post.mapper;
+
+import com.honeypot.domain.post.dto.UsedTradePostDto;
+import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
+import com.honeypot.domain.post.entity.UsedTradePost;
+import com.honeypot.domain.post.entity.enums.TradeStatus;
+import com.honeypot.domain.post.entity.enums.TradeType;
+import com.honeypot.domain.reaction.entity.enums.ReactionTarget;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", imports = {TradeStatus.class, TradeType.class})
+public interface UsedTradePostMapper {
+
+    @Mapping(target = "comments", ignore = true)
+    @Mapping(target = "id", source = "postId")
+    @Mapping(target = "createdAt", source = "uploadedAt")
+    UsedTradePost toEntity(UsedTradePostDto dto);
+
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "lastModifiedAt", ignore = true)
+    @Mapping(target = "comments", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "tradeStatus", expression = "java(TradeStatus.ONGOING)")
+    @Mapping(target = "tradeType", expression = "java(TradeType.valueOf(dto.getTradeType()))")
+    @Mapping(target = "writer.id", source = "writerId")
+    UsedTradePost toEntity(UsedTradePostUploadRequest dto);
+
+    @Mapping(target = "commentCount", ignore = true)
+    @Mapping(target = "likeReactionCount", ignore = true)
+    @Mapping(target = "isLiked", ignore = true)
+    @Mapping(target = "likeReactionId", ignore = true)
+    @Mapping(target = "thumbnailImageFile", ignore = true)
+    @Mapping(target = "attachedFiles", ignore = true)
+    @InheritInverseConfiguration
+    UsedTradePostDto toDto(UsedTradePost entity);
+
+    List<UsedTradePostDto> toDto(List<UsedTradePost> entities);
+
+}

--- a/src/main/java/com/honeypot/domain/post/mapper/UsedTradePostMapper.java
+++ b/src/main/java/com/honeypot/domain/post/mapper/UsedTradePostMapper.java
@@ -5,7 +5,6 @@ import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
 import com.honeypot.domain.post.entity.UsedTradePost;
 import com.honeypot.domain.post.entity.enums.TradeStatus;
 import com.honeypot.domain.post.entity.enums.TradeType;
-import com.honeypot.domain.reaction.entity.enums.ReactionTarget;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -24,7 +23,7 @@ public interface UsedTradePostMapper {
     @Mapping(target = "lastModifiedAt", ignore = true)
     @Mapping(target = "comments", ignore = true)
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "tradeStatus", expression = "java(TradeStatus.ONGOING)")
+    @Mapping(target = "tradeStatus", expression = "java(TradeStatus.valueOf(dto.getTradeStatus()))")
     @Mapping(target = "tradeType", expression = "java(TradeType.valueOf(dto.getTradeType()))")
     @Mapping(target = "writer.id", source = "writerId")
     UsedTradePost toEntity(UsedTradePostUploadRequest dto);

--- a/src/main/java/com/honeypot/domain/post/repository/NormalPostQuerydslRepositoryImpl.java
+++ b/src/main/java/com/honeypot/domain/post/repository/NormalPostQuerydslRepositoryImpl.java
@@ -24,14 +24,13 @@ import java.util.List;
 import static com.honeypot.domain.file.QFile.file;
 import static com.honeypot.domain.post.entity.QNormalPost.normalPost;
 import static com.honeypot.domain.post.entity.QPost.post;
-import static com.honeypot.domain.post.entity.QUsedTradePost.usedTradePost;
 import static com.honeypot.domain.reaction.entity.QReaction.reaction;
 import static com.querydsl.jpa.JPAExpressions.select;
 import static com.querydsl.jpa.JPAExpressions.selectOne;
 
 @Repository
 @RequiredArgsConstructor
-public class QuerydslRepositoryImpl {
+public class NormalPostQuerydslRepositoryImpl {
 
     @Value("${cloud.aws.s3.domain}")
     private String s3Domain;

--- a/src/main/java/com/honeypot/domain/post/repository/UsedTradePostRepository.java
+++ b/src/main/java/com/honeypot/domain/post/repository/UsedTradePostRepository.java
@@ -1,0 +1,9 @@
+package com.honeypot.domain.post.repository;
+
+import com.honeypot.domain.post.entity.UsedTradePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UsedTradePostRepository extends JpaRepository<UsedTradePost, Long> {
+}

--- a/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
+++ b/src/main/java/com/honeypot/domain/post/service/NormalPostService.java
@@ -13,8 +13,7 @@ import com.honeypot.domain.file.PostFileUploadRequest;
 import com.honeypot.domain.post.entity.NormalPost;
 import com.honeypot.domain.post.mapper.NormalPostMapper;
 import com.honeypot.domain.post.repository.NormalPostRepository;
-import com.honeypot.domain.post.repository.QuerydslRepositoryImpl;
-import com.honeypot.domain.reaction.entity.enums.ReactionType;
+import com.honeypot.domain.post.repository.NormalPostQuerydslRepositoryImpl;
 import com.honeypot.domain.reaction.repository.ReactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,7 +33,7 @@ import java.util.List;
 @Validated
 public class NormalPostService {
 
-    private final QuerydslRepositoryImpl querydslRepository;
+    private final NormalPostQuerydslRepositoryImpl querydslRepository;
 
     private final NormalPostMapper normalPostMapper;
 

--- a/src/main/java/com/honeypot/domain/post/service/UsedTradePostService.java
+++ b/src/main/java/com/honeypot/domain/post/service/UsedTradePostService.java
@@ -1,0 +1,127 @@
+package com.honeypot.domain.post.service;
+
+import com.honeypot.common.model.exceptions.InvalidAuthorizationException;
+import com.honeypot.common.validation.groups.InsertContext;
+import com.honeypot.domain.file.AttachedFileResponse;
+import com.honeypot.domain.file.FileUploadService;
+import com.honeypot.domain.file.PostFileUploadRequest;
+import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.member.repository.MemberRepository;
+import com.honeypot.domain.post.dto.UsedTradePostDto;
+import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
+import com.honeypot.domain.post.entity.UsedTradePost;
+import com.honeypot.domain.post.entity.enums.TradeStatus;
+import com.honeypot.domain.post.entity.enums.TradeType;
+import com.honeypot.domain.post.mapper.UsedTradePostMapper;
+import com.honeypot.domain.post.repository.UsedTradePostQuerydslRepository;
+import com.honeypot.domain.post.repository.UsedTradePostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.persistence.EntityNotFoundException;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Validated
+public class UsedTradePostService {
+
+    private final UsedTradePostQuerydslRepository usedTradePostQuerydslRepository;
+
+    private final UsedTradePostMapper usedTradePostMapper;
+
+    private final UsedTradePostRepository usedTradePostRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final FileUploadService fileUploadService;
+
+    @Transactional(readOnly = true)
+    public Page<UsedTradePostDto> pageList(Pageable pageable, Long memberId) {
+        Page<UsedTradePostDto> result = usedTradePostQuerydslRepository
+                .findAllPostWithCommentAndReactionCount(pageable, memberId);
+        return new PageImpl<>(
+                result.getContent(),
+                pageable,
+                result.getTotalElements()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public UsedTradePostDto find(@NotNull Long postId, Long memberId) {
+        UsedTradePost usedTradePost = usedTradePostRepository
+                .findById(postId)
+                .orElseThrow(EntityNotFoundException::new);
+        return usedTradePostQuerydslRepository.findPostDetailById(postId, memberId);
+    }
+
+    @Transactional
+    @Validated(InsertContext.class)
+    public UsedTradePostDto upload(@Valid UsedTradePostUploadRequest request) {
+        request.setTradeStatus(TradeStatus.ONGOING.toString());
+        UsedTradePost created = usedTradePostRepository.save(usedTradePostMapper.toEntity(request));
+
+        long writerId = created.getWriter().getId();
+        Member writer = memberRepository
+                .findById(writerId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        UsedTradePostDto result = usedTradePostMapper.toDto(created);
+        result.getWriter().setNickname(writer.getNickname());
+
+        List<PostFileUploadRequest> attachedFiles = request.getAttachedFiles();
+        if (attachedFiles != null) {
+            List<AttachedFileResponse> files = attachedFiles.stream()
+                    .filter(PostFileUploadRequest::isWillBeUploaded)
+                    .peek(f -> f.setLinkPostId(result.getPostId()))
+                    .map(fileUploadService::linkFileWithPost)
+                    .toList();
+
+            result.setAttachedFiles(files);
+        }
+
+        return result;
+    }
+
+    @Transactional
+    @Validated(InsertContext.class)
+    public UsedTradePostDto update(Long postId, UsedTradePostUploadRequest uploadRequest) {
+        UsedTradePost usedTradePost = usedTradePostRepository
+                .findById(postId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        if (!usedTradePost.getWriter().getId().equals(uploadRequest.getWriterId())) {
+            throw new InvalidAuthorizationException();
+        }
+
+        usedTradePost.setTitle(uploadRequest.getTitle());
+        usedTradePost.setContent(uploadRequest.getContent());
+        usedTradePost.setGoodsPrice(uploadRequest.getGoodsPrice());
+        usedTradePost.setTradeStatus(TradeStatus.valueOf(uploadRequest.getTradeStatus()));
+        usedTradePost.setTradeType(TradeType.valueOf(uploadRequest.getTradeType()));
+        usedTradePost.setChatRoomLink(uploadRequest.getChatRoomLink());
+
+        return usedTradePostMapper.toDto(usedTradePostRepository.save(usedTradePost));
+    }
+
+    @Transactional
+    public void delete(Long postId, @NotNull Long memberId) {
+        UsedTradePost usedTradePost = usedTradePostRepository
+                .findById(postId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        if (!usedTradePost.getWriter().getId().equals(memberId)) {
+            throw new InvalidAuthorizationException();
+        }
+
+        usedTradePostRepository.delete(usedTradePost);
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/post/service/UsedTradePostService.java
+++ b/src/main/java/com/honeypot/domain/post/service/UsedTradePostService.java
@@ -7,6 +7,7 @@ import com.honeypot.domain.file.FileUploadService;
 import com.honeypot.domain.file.PostFileUploadRequest;
 import com.honeypot.domain.member.entity.Member;
 import com.honeypot.domain.member.repository.MemberRepository;
+import com.honeypot.domain.post.dto.UsedTradeModifyRequest;
 import com.honeypot.domain.post.dto.UsedTradePostDto;
 import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
 import com.honeypot.domain.post.entity.UsedTradePost;
@@ -92,7 +93,7 @@ public class UsedTradePostService {
 
     @Transactional
     @Validated(InsertContext.class)
-    public UsedTradePostDto update(Long postId, UsedTradePostUploadRequest uploadRequest) {
+    public UsedTradePostDto update(Long postId, @Valid UsedTradePostUploadRequest uploadRequest) {
         UsedTradePost usedTradePost = usedTradePostRepository
                 .findById(postId)
                 .orElseThrow(EntityNotFoundException::new);
@@ -107,6 +108,22 @@ public class UsedTradePostService {
         usedTradePost.setTradeStatus(TradeStatus.valueOf(uploadRequest.getTradeStatus()));
         usedTradePost.setTradeType(TradeType.valueOf(uploadRequest.getTradeType()));
         usedTradePost.setChatRoomLink(uploadRequest.getChatRoomLink());
+
+        return usedTradePostMapper.toDto(usedTradePostRepository.save(usedTradePost));
+    }
+
+    @Transactional
+    @Validated(InsertContext.class)
+    public UsedTradePostDto updateTradeStatus(@NotNull Long postId, @Valid UsedTradeModifyRequest request) {
+        UsedTradePost usedTradePost = usedTradePostRepository
+                .findById(postId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        if (!usedTradePost.getWriter().getId().equals(request.getWriterId())) {
+            throw new InvalidAuthorizationException();
+        }
+
+        usedTradePost.setTradeStatus(TradeStatus.valueOf(request.getTradeStatus()));
 
         return usedTradePostMapper.toDto(usedTradePostRepository.save(usedTradePost));
     }

--- a/src/test/java/com/honeypot/domain/post/mapper/UsedTradePostMapperTest.java
+++ b/src/test/java/com/honeypot/domain/post/mapper/UsedTradePostMapperTest.java
@@ -1,0 +1,135 @@
+package com.honeypot.domain.post.mapper;
+
+import com.honeypot.domain.comment.entity.Comment;
+import com.honeypot.domain.member.dto.WriterDto;
+import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.post.dto.UsedTradePostDto;
+import com.honeypot.domain.post.dto.UsedTradePostUploadRequest;
+import com.honeypot.domain.post.entity.UsedTradePost;
+import com.honeypot.domain.post.entity.enums.TradeStatus;
+import com.honeypot.domain.post.entity.enums.TradeType;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class UsedTradePostMapperTest {
+
+    private final UsedTradePostMapper mapper = Mappers.getMapper(UsedTradePostMapper.class);
+
+    @Test
+    void toEntity() {
+        // Arrange
+        LocalDateTime uploadedAt = LocalDateTime.of(2022, 7, 28, 22, 0, 0);
+        UsedTradePostDto dto = UsedTradePostDto.builder()
+                .postId(1)
+                .title("title")
+                .content("content")
+                .writer(WriterDto.builder()
+                        .id(1)
+                        .nickname("nickname")
+                        .build())
+                .commentCount(10L)
+                .likeReactionCount(5L)
+                .isLiked(true)
+                .likeReactionId(10L)
+                .thumbnailImageFile(null)
+                .uploadedAt(uploadedAt)
+                .lastModifiedAt(uploadedAt)
+
+                .goodsPrice(10000)
+                .tradeType(TradeType.SELL)
+                .tradeStatus(TradeStatus.ONGOING)
+                .chatRoomLink(null)
+                .build();
+
+        // Act
+        UsedTradePost entity = mapper.toEntity(dto);
+
+        // Assert
+        assertEquals(dto.getPostId(), entity.getId());
+        assertEquals(dto.getTitle(), entity.getTitle());
+        assertEquals(dto.getContent(), entity.getContent());
+        assertEquals(dto.getWriter().getId(), entity.getWriter().getId());
+        assertEquals(dto.getWriter().getNickname(), entity.getWriter().getNickname());
+        assertEquals(dto.getGoodsPrice(), entity.getGoodsPrice());
+        assertEquals(dto.getTradeType(), entity.getTradeType());
+        assertEquals(dto.getTradeStatus(), entity.getTradeStatus());
+        assertEquals(dto.getChatRoomLink(), entity.getChatRoomLink());
+        assertEquals(dto.getUploadedAt(), entity.getCreatedAt());
+        assertEquals(dto.getLastModifiedAt(), entity.getLastModifiedAt());
+    }
+
+    @Test
+    void toEntity_FromUsedTradePostUploadRequest() {
+        // Arrange
+        UsedTradePostUploadRequest dto = UsedTradePostUploadRequest.builder()
+                .title("title")
+                .content("content")
+                .writerId(1L)
+                .attachedFiles(null)
+                .goodsPrice(20000)
+                .tradeType(TradeType.BUY.toString())
+                .chatRoomLink("chatRoomLink")
+                .build();
+
+        // Act
+        UsedTradePost entity = mapper.toEntity(dto);
+
+        // Assert
+        assertEquals(dto.getTitle(), entity.getTitle());
+        assertEquals(dto.getContent(), entity.getContent());
+        assertEquals(dto.getWriterId(), entity.getWriter().getId());
+        assertEquals(dto.getGoodsPrice(), entity.getGoodsPrice());
+        assertEquals(dto.getTradeType(), entity.getTradeType().toString());
+        assertEquals(TradeStatus.ONGOING, entity.getTradeStatus());
+    }
+
+    @Test
+    void toDto() {
+        // Arrange
+        LocalDateTime uploadedAt = LocalDateTime.of(2022, 7, 28, 22, 0, 0);
+        UsedTradePost entity = UsedTradePost.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .writer(Member.builder()
+                        .id(1L)
+                        .nickname("nickname")
+                        .build())
+                .comments(List.of(Comment.builder().build()))
+                .createdAt(uploadedAt)
+                .lastModifiedAt(uploadedAt)
+
+                .goodsPrice(15000)
+                .tradeType(TradeType.SELL)
+                .tradeStatus(TradeStatus.COMPLETE)
+                .chatRoomLink("https://example.com/adfsafsdca")
+                .build();
+
+        // Act
+        UsedTradePostDto dto = mapper.toDto(entity);
+
+        // Assert
+        assertEquals(entity.getId(), dto.getPostId());
+        assertEquals(entity.getTitle(), dto.getTitle());
+        assertEquals(entity.getContent(), dto.getContent());
+        assertEquals(entity.getWriter().getId(), dto.getWriter().getId());
+        assertEquals(entity.getWriter().getNickname(), dto.getWriter().getNickname());
+        assertNull(dto.getCommentCount());
+        assertNull(dto.getLikeReactionCount());
+        assertNull(dto.getLikeReactionId());
+        assertNull(dto.getIsLiked());
+        assertEquals(entity.getCreatedAt(), dto.getUploadedAt());
+        assertEquals(entity.getLastModifiedAt(), dto.getUploadedAt());
+        assertEquals(entity.getGoodsPrice(), dto.getGoodsPrice());
+        assertEquals(entity.getTradeStatus(), dto.getTradeStatus());
+        assertEquals(entity.getTradeType(), dto.getTradeType());
+        assertEquals(entity.getChatRoomLink(), dto.getChatRoomLink());
+    }
+
+}

--- a/src/test/java/com/honeypot/domain/post/mapper/UsedTradePostMapperTest.java
+++ b/src/test/java/com/honeypot/domain/post/mapper/UsedTradePostMapperTest.java
@@ -73,6 +73,7 @@ class UsedTradePostMapperTest {
                 .writerId(1L)
                 .attachedFiles(null)
                 .goodsPrice(20000)
+                .tradeStatus(TradeStatus.COMPLETE.toString())
                 .tradeType(TradeType.BUY.toString())
                 .chatRoomLink("chatRoomLink")
                 .build();
@@ -86,7 +87,7 @@ class UsedTradePostMapperTest {
         assertEquals(dto.getWriterId(), entity.getWriter().getId());
         assertEquals(dto.getGoodsPrice(), entity.getGoodsPrice());
         assertEquals(dto.getTradeType(), entity.getTradeType().toString());
-        assertEquals(TradeStatus.ONGOING, entity.getTradeStatus());
+        assertEquals(dto.getTradeStatus(), entity.getTradeStatus().toString());
     }
 
     @Test


### PR DESCRIPTION
### What's Changed?
- 중고거래 게시글 CRUD API 추가
  - 목록조회 (GET /api/posts/used-trades)
  - 상세조회 (GET /api/posts/used-trades/{postId})
  - 작성 (POST /api/posts/used-trades)
  - 수정 (PUT /api/posts/used-trades/{postId})
  - 거래상태 수정 (PATCH /api/posts/used-trades/{postId})
  - 삭제 (DELETE /api/posts/used-trades/{postId})

### Related Issue
- resolved: #42 