### PR TITLE
Feature/cors

### DIFF
--- a/src/main/java/com/honeypot/common/config/WebConfig.java
+++ b/src/main/java/com/honeypot/common/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.honeypot.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -9,13 +10,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${domain.client.web}")
+    private String webClientDomain;
+
     @Bean
     public WebMvcConfigurer webMvcConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("*")
+                        .allowedOrigins(webClientDomain)
+                        .allowCredentials(true)
                         .allowedMethods(
                                 HttpMethod.GET.name(),
                                 HttpMethod.POST.name(),

--- a/src/main/java/com/honeypot/domain/auth/api/AuthCode.java
+++ b/src/main/java/com/honeypot/domain/auth/api/AuthCode.java
@@ -1,0 +1,12 @@
+package com.honeypot.domain.auth.api;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AuthCode {
+
+    private String authorizationCode;
+
+}

--- a/src/main/java/com/honeypot/domain/auth/service/JwtAuthTokenManagerService.java
+++ b/src/main/java/com/honeypot/domain/auth/service/JwtAuthTokenManagerService.java
@@ -59,13 +59,13 @@ public class JwtAuthTokenManagerService implements AuthTokenManagerService {
                     .parseClaimsJws(token);
             return true;
         } catch (SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT signature.", e);
+            log.info("Invalid JWT signature. {}", e.getMessage());
         } catch (ExpiredJwtException e) {
-            log.info("Expired JWT token.", e);
+            log.info("Expired JWT token. {}", e.getMessage());
         } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT token.", e);
+            log.info("Unsupported JWT token. {}", e.getMessage());
         } catch (IllegalArgumentException e) {
-            log.info("Invalid JWT.", e);
+            log.info("Invalid JWT. {}", e.getMessage());
         }
 
         return false;


### PR DESCRIPTION
### What's Changed?
- `Access-Control-Allow-Credential` 헤더 설정 → `Cookie` 헤더 읽기 가능하도록 함
- 로그인, 토큰 재발급 API 응답으로 반환되는 `Cookie` 정보 설정 (HttpOnly, Secure, Domain, Path, Age)

### Related Issue
- resolved: #49 