### PR TITLE
신고하기 API 추가, refresh token 쿠키 강제 만료, 기타 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.honeypot'
-version '0.0.10'
+version '1.0.0'
 sourceCompatibility = '17'
 
 repositories {

--- a/src/main/java/com/honeypot/common/advice/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/honeypot/common/advice/GlobalApiExceptionHandler.java
@@ -1,10 +1,7 @@
 package com.honeypot.common.advice;
 
 import com.honeypot.common.model.dto.ErrorResponse;
-import com.honeypot.common.model.exceptions.BadRequestException;
-import com.honeypot.common.model.exceptions.InvalidAuthorizationException;
-import com.honeypot.common.model.exceptions.InvalidTokenException;
-import com.honeypot.common.model.exceptions.RefreshFailedException;
+import com.honeypot.common.model.exceptions.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -37,6 +34,11 @@ public class GlobalApiExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ErrorResponse> badRequestException(BadRequestException e) {
+        return ErrorResponse.of(e, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ReportTargetNotFoundException.class)
+    public ResponseEntity<ErrorResponse> reportTargetNotFoundException(ReportTargetNotFoundException e) {
         return ErrorResponse.of(e, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/honeypot/common/model/exceptions/ReportTargetNotFoundException.java
+++ b/src/main/java/com/honeypot/common/model/exceptions/ReportTargetNotFoundException.java
@@ -1,0 +1,11 @@
+package com.honeypot.common.model.exceptions;
+
+import com.honeypot.domain.report.ReportTarget;
+
+public class ReportTargetNotFoundException extends BaseException {
+
+    public ReportTargetNotFoundException(ReportTarget target, Long targetId) {
+        super("HRE002", String.format("ReportTarget [%s:%d] not found.", target, targetId));
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/honeypot/domain/auth/api/AuthApi.java
@@ -62,13 +62,17 @@ public class AuthApi {
     }
 
     @PostMapping("/token")
-    public ResponseEntity<?> refreshToken(@CookieValue("refreshToken") String refreshToken,
+    public ResponseEntity<?> refreshToken(@CookieValue(value = "refreshToken", required = false) String refreshToken,
                                           @RequestBody RefreshTokenRequest request) {
 
         if (!request.getGrantType().equals("refresh_token")) {
             Map<String, String> errorMessages = new HashMap<>();
             errorMessages.put("grantType", "grantType is must me 'refresh_token'");
             throw new BadRequestException(errorMessages);
+        }
+
+        if (refreshToken == null) {
+            return ResponseEntity.noContent().build();
         }
 
         if (!authTokenManagerService.validate(refreshToken)) {

--- a/src/main/java/com/honeypot/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/honeypot/domain/auth/api/AuthApi.java
@@ -1,7 +1,6 @@
 package com.honeypot.domain.auth.api;
 
 import com.honeypot.common.model.exceptions.BadRequestException;
-import com.honeypot.common.model.exceptions.RefreshFailedException;
 import com.honeypot.common.model.properties.JwtProperties;
 import com.honeypot.domain.auth.dto.AuthCode;
 import com.honeypot.domain.auth.dto.LoginResponse;
@@ -9,12 +8,12 @@ import com.honeypot.domain.auth.dto.RefreshTokenRequest;
 import com.honeypot.domain.auth.dto.kakao.KakaoAuthCode;
 import com.honeypot.domain.auth.service.contracts.AuthTokenManagerService;
 import com.honeypot.domain.auth.service.contracts.LoginService;
-import com.honeypot.domain.member.entity.Member;
 import com.honeypot.domain.member.service.MemberFindService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -67,7 +66,7 @@ public class AuthApi {
 
         if (!request.getGrantType().equals("refresh_token")) {
             Map<String, String> errorMessages = new HashMap<>();
-            errorMessages.put("grantType", "grantType is must me 'refresh_token'");
+            errorMessages.put("grantType", "grantType is must be 'refresh_token'");
             throw new BadRequestException(errorMessages);
         }
 
@@ -76,36 +75,40 @@ public class AuthApi {
         }
 
         if (!authTokenManagerService.validate(refreshToken)) {
-            throw new RefreshFailedException();
+            return getExpiredRefreshTokenResponse(refreshToken);
+//            throw new RefreshFailedException();
         }
 
         Long memberId = authTokenManagerService.getMemberId(refreshToken);
-        Member member = memberFindService.findById(memberId)
-                .orElseThrow(RefreshFailedException::new);
+        if (memberFindService.findById(memberId).isEmpty()) {
+            return getExpiredRefreshTokenResponse(refreshToken);
+        }
 
-        String newAccessToken = authTokenManagerService.issueAccessToken(member.getId());
-        String newRefreshToken = authTokenManagerService.issueRefreshToken(member.getId());
-
-        LoginResponse response = LoginResponse.builder()
-                .memberId(memberId)
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
-                .build();
+        String newAccessToken = authTokenManagerService.issueAccessToken(memberId);
+        String newRefreshToken = authTokenManagerService.issueRefreshToken(memberId);
 
         return ResponseEntity
                 .ok()
                 .header(HttpHeaders.SET_COOKIE, getHttpOnlyCookie(newRefreshToken, false).toString())
-                .body(response);
+                .body(LoginResponse.builder()
+                        .memberId(memberId)
+                        .accessToken(newAccessToken)
+                        .refreshToken(newRefreshToken)
+                        .build()
+                );
     }
 
     @DeleteMapping("/token")
     public ResponseEntity<?> expireRefreshToken(@CookieValue("refreshToken") String refreshToken) {
+        return getExpiredRefreshTokenResponse(refreshToken);
+    }
+
+    private ResponseEntity<?> getExpiredRefreshTokenResponse(String refreshToken) {
         return ResponseEntity
-                .noContent()
+                .status(HttpStatus.FORBIDDEN)
                 .header(HttpHeaders.SET_COOKIE, getHttpOnlyCookie(refreshToken, true).toString())
                 .build();
     }
-
 
     private ResponseCookie getHttpOnlyCookie(String refreshToken, boolean isExpired) {
         return ResponseCookie

--- a/src/main/java/com/honeypot/domain/post/entity/Post.java
+++ b/src/main/java/com/honeypot/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package com.honeypot.domain.post.entity;
 
 import com.honeypot.common.entity.BaseTimeEntity;
 import com.honeypot.domain.comment.entity.Comment;
+import com.honeypot.domain.file.File;
 import com.honeypot.domain.member.entity.Member;
 import com.honeypot.domain.reaction.entity.CommentReaction;
 import com.honeypot.domain.reaction.entity.PostReaction;
@@ -52,6 +53,10 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<CommentReaction> commentReactions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @Builder.Default
+    private List<File> attachedFiles = new ArrayList<>();
 
     @Column(insertable = false, updatable = false)
     private String type;

--- a/src/main/java/com/honeypot/domain/post/repository/GroupBuyingPostQuerydslRepository.java
+++ b/src/main/java/com/honeypot/domain/post/repository/GroupBuyingPostQuerydslRepository.java
@@ -75,7 +75,6 @@ public class GroupBuyingPostQuerydslRepository {
                 .select(post.id)
                 .from(post)
                 .innerJoin(member).on(post.writer.id.eq(member.id))
-                .fetchJoin()
                 .where(member.id.eq(memberId)
                         .and(post.type.eq(PostType.GROUP_BUYING.name()))
                 )

--- a/src/main/java/com/honeypot/domain/report/Report.java
+++ b/src/main/java/com/honeypot/domain/report/Report.java
@@ -1,0 +1,38 @@
+package com.honeypot.domain.report;
+
+import com.honeypot.common.entity.BaseTimeEntity;
+import com.honeypot.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@SuperBuilder
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target", nullable = false)
+    private ReportTarget target;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member reporter;
+
+}

--- a/src/main/java/com/honeypot/domain/report/ReportApi.java
+++ b/src/main/java/com/honeypot/domain/report/ReportApi.java
@@ -1,0 +1,42 @@
+package com.honeypot.domain.report;
+
+import com.honeypot.common.model.exceptions.InvalidTokenException;
+import com.honeypot.common.utils.SecurityUtils;
+import com.honeypot.domain.post.dto.GroupBuyingPostDto;
+import com.honeypot.domain.post.dto.GroupBuyingPostUploadRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
+@Validated
+public class ReportApi {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<?> upload(@Valid @RequestBody ReportUploadRequest uploadRequest) {
+        Long memberId = SecurityUtils.getCurrentMemberId().orElseThrow(InvalidTokenException::new);
+        uploadRequest.setReporterId(memberId);
+
+        ReportDto uploaded = reportService.upload(uploadRequest);
+
+        return ResponseEntity
+                .created(ServletUriComponentsBuilder
+                        .fromCurrentRequest()
+                        .path("/{reportId}")
+                        .buildAndExpand(uploaded.getReportId())
+                        .toUri())
+                .body(uploaded);
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/report/ReportDto.java
+++ b/src/main/java/com/honeypot/domain/report/ReportDto.java
@@ -1,0 +1,26 @@
+package com.honeypot.domain.report;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ReportDto {
+
+    private Long reportId;
+
+    private ReportTarget target;
+
+    private Long targetId;
+
+    private String reason;
+
+    private Long reporterId;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastModifiedAt;
+
+}

--- a/src/main/java/com/honeypot/domain/report/ReportMapper.java
+++ b/src/main/java/com/honeypot/domain/report/ReportMapper.java
@@ -1,0 +1,24 @@
+package com.honeypot.domain.report;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", imports = ReportTarget.class)
+public interface ReportMapper {
+
+    @Mapping(target = "id", source = "reportId")
+    @Mapping(target = "reporter.id", source = "reporterId")
+    Report toEntity(ReportDto dto);
+
+    @Mapping(target = "reporter.id", source = "reporterId")
+    Report toEntity(ReportUploadRequest dto);
+
+    @InheritInverseConfiguration
+    ReportDto toDto(Report entity);
+
+    List<ReportDto> toDto(List<Report> entities);
+
+}

--- a/src/main/java/com/honeypot/domain/report/ReportRepository.java
+++ b/src/main/java/com/honeypot/domain/report/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.honeypot.domain.report;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/honeypot/domain/report/ReportService.java
+++ b/src/main/java/com/honeypot/domain/report/ReportService.java
@@ -1,0 +1,42 @@
+package com.honeypot.domain.report;
+
+import com.honeypot.common.model.exceptions.ReportTargetNotFoundException;
+import com.honeypot.common.validation.groups.InsertContext;
+import com.honeypot.domain.comment.repository.CommentRepository;
+import com.honeypot.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+@Service
+@RequiredArgsConstructor
+@Validated
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    private final PostRepository postRepository;
+
+    private final CommentRepository commentRepository;
+
+    private final ReportMapper reportMapper;
+
+    @Transactional
+    @Validated(InsertContext.class)
+    public ReportDto upload(@Valid ReportUploadRequest request) {
+        ReportTarget target = request.getTarget();
+        Long targetId = request.getTargetId();
+        if (target == ReportTarget.POST) {
+            postRepository.findById(targetId).orElseThrow(() -> new ReportTargetNotFoundException(target, targetId));
+        } else if (target == ReportTarget.COMMENT) {
+            commentRepository.findById(targetId).orElseThrow(() -> new ReportTargetNotFoundException(target, targetId));
+        }
+
+        Report uploaded = reportRepository.save(reportMapper.toEntity(request));
+        return reportMapper.toDto(uploaded);
+    }
+
+}

--- a/src/main/java/com/honeypot/domain/report/ReportTarget.java
+++ b/src/main/java/com/honeypot/domain/report/ReportTarget.java
@@ -1,0 +1,7 @@
+package com.honeypot.domain.report;
+
+public enum ReportTarget {
+
+    POST, COMMENT
+
+}

--- a/src/main/java/com/honeypot/domain/report/ReportUploadRequest.java
+++ b/src/main/java/com/honeypot/domain/report/ReportUploadRequest.java
@@ -1,0 +1,30 @@
+package com.honeypot.domain.report;
+
+import com.honeypot.common.validation.groups.InsertContext;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportUploadRequest {
+
+    @NotNull
+    private ReportTarget target;
+
+    @NotNull
+    private Long targetId;
+
+    @NotBlank
+    private String reason;
+
+    @NotNull(groups = InsertContext.class)
+    private Long reporterId;
+
+}

--- a/src/main/java/com/honeypot/domain/search/PostSearchCriteria.java
+++ b/src/main/java/com/honeypot/domain/search/PostSearchCriteria.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 public class PostSearchCriteria {
 
     @NotNull
-    @Length(min = 2, max = 30)
+    @Length(min = 1, max = 30)
     private String keyword;
 
     @NotNull

--- a/src/test/java/com/honeypot/HoneyPotApplicationTest.java
+++ b/src/test/java/com/honeypot/HoneyPotApplicationTest.java
@@ -2,9 +2,11 @@ package com.honeypot;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class HoneyPotApplicationTest {
 

--- a/src/test/java/com/honeypot/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/honeypot/domain/member/api/MemberApiTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,8 +30,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(MemberApi.class)
 @ActiveProfiles("test")
@@ -163,15 +163,18 @@ class MemberApiTest {
         // Act
         ResultActions actions = mockMvc.perform(delete("/api/members/" + memberId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", token)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .header(HttpHeaders.COOKIE, "refreshToken=refreshToken;")
         );
 
         // Assert
-        actions.andExpect(status().isNoContent()).andReturn();
+        actions.andExpect(status().isNoContent())
+                .andExpect(header().exists(HttpHeaders.SET_COOKIE))
+                .andReturn();
     }
 
     @Test
-    void deleteMember_Fail_InvalidAuthorizationException() throws Exception {
+    void deleteMember_Fail_InvalidAuthorizationException() {
         // Arrange
         String token = "Bearer test";
         Long memberId = 1L;
@@ -183,7 +186,8 @@ class MemberApiTest {
         assertThrows(NestedServletException.class, () -> {
             mockMvc.perform(delete("/api/members/" + memberId)
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .header("Authorization", token)
+                    .header(HttpHeaders.AUTHORIZATION, token)
+                    .header(HttpHeaders.COOKIE, "refreshToken=refreshToken;")
             );
         });
     }

--- a/src/test/java/com/honeypot/domain/report/ReportApiTest.java
+++ b/src/test/java/com/honeypot/domain/report/ReportApiTest.java
@@ -1,0 +1,118 @@
+package com.honeypot.domain.report;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.honeypot.common.utils.SecurityUtils;
+import com.honeypot.domain.auth.service.contracts.AuthTokenManagerService;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportApi.class)
+@ActiveProfiles("test")
+@MockBean(classes = {JpaMetamodelMappingContext.class, ReportService.class, AuthTokenManagerService.class})
+@ExtendWith(MockitoExtension.class)
+class ReportApiTest {
+
+    @Mock
+    private ReportService reportService;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static MockedStatic<SecurityUtils> mockStatic;
+
+    @BeforeAll
+    public static void setup() {
+        mockStatic = mockStatic(SecurityUtils.class);
+    }
+
+    @BeforeEach
+    public void before() {
+        reportService = mock(ReportService.class);
+        ReportApi reportApi = new ReportApi(reportService);
+        mockMvc = MockMvcBuilders.standaloneSetup(reportApi).build();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        mockStatic.close();
+    }
+
+    @Test
+    void upload() throws Exception {
+        // Arrange
+        String token = "Bearer test";
+        ReportTarget target = ReportTarget.POST;
+        Long targetId = 1L;
+        String reason = "사유";
+        Long reporterId = 2L;
+
+        when(SecurityUtils.getCurrentMemberId()).thenReturn(Optional.of(reporterId));
+
+        ReportUploadRequest uploadRequest = ReportUploadRequest.builder()
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(uploadRequest);
+        uploadRequest.setReporterId(reporterId);
+
+        LocalDateTime createdAt = LocalDateTime.now();
+        ReportDto uploaded = ReportDto.builder()
+                .reportId(1L)
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .reporterId(reporterId)
+                .createdAt(createdAt)
+                .lastModifiedAt(createdAt)
+                .build();
+
+        when(reportService.upload(uploadRequest)).thenReturn(uploaded);
+
+        // Act
+        ResultActions actions = mockMvc.perform(post("/api/reports")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .content(requestBody)
+        );
+
+        // Assert
+        actions.andExpect(status().isCreated())
+                .andExpect(jsonPath("reportId").exists())
+                .andExpect(jsonPath("target").exists())
+                .andExpect(jsonPath("targetId").exists())
+                .andExpect(jsonPath("reason").exists())
+                .andExpect(jsonPath("reporterId").exists())
+                .andExpect(jsonPath("createdAt").exists())
+                .andExpect(jsonPath("lastModifiedAt").exists())
+                .andReturn();
+    }
+
+}

--- a/src/test/java/com/honeypot/domain/report/ReportMapperTest.java
+++ b/src/test/java/com/honeypot/domain/report/ReportMapperTest.java
@@ -1,0 +1,89 @@
+package com.honeypot.domain.report;
+
+import com.honeypot.domain.member.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportMapperTest {
+
+    private final ReportMapper mapper = Mappers.getMapper(ReportMapper.class);
+
+    @Test
+    void toEntity() {
+        // Arrange
+        LocalDateTime createdAt = LocalDateTime.of(2022, 7, 28, 22, 0, 0);
+        ReportDto dto = ReportDto.builder()
+                .reportId(1L)
+                .target(ReportTarget.POST)
+                .targetId(2921L)
+                .reason("그냥 신고하고 싶었습니다.")
+                .reporterId(12L)
+                .createdAt(createdAt)
+                .lastModifiedAt(createdAt)
+                .build();
+
+        // Act
+        Report entity = mapper.toEntity(dto);
+
+        // Assert
+        assertEquals(dto.getReportId(), entity.getId());
+        assertEquals(dto.getTarget(), entity.getTarget());
+        assertEquals(dto.getTargetId(), entity.getTargetId());
+        assertEquals(dto.getReason(), entity.getReason());
+        assertEquals(dto.getReporterId(), entity.getReporter().getId());
+        assertEquals(dto.getCreatedAt(), entity.getCreatedAt());
+        assertEquals(dto.getLastModifiedAt(), entity.getLastModifiedAt());
+    }
+
+    @Test
+    void toEntity_FromReportUploadRequest() {
+        // Arrange
+        ReportUploadRequest dto = ReportUploadRequest.builder()
+                .target(ReportTarget.POST)
+                .targetId(123123L)
+                .reason("내맘..")
+                .reporterId(1L)
+                .build();
+
+        // Act
+        Report entity = mapper.toEntity(dto);
+
+        // Assert
+        assertEquals(dto.getTarget(), entity.getTarget());
+        assertEquals(dto.getTargetId(), entity.getTargetId());
+        assertEquals(dto.getReason(), entity.getReason());
+        assertEquals(dto.getReporterId(), entity.getReporter().getId());
+    }
+
+    @Test
+    void toDto() {
+        // Arrange
+        LocalDateTime createdAt = LocalDateTime.of(2022, 7, 28, 22, 0, 0);
+        Report entity = Report.builder()
+                .id(1L)
+                .target(ReportTarget.POST)
+                .targetId(123L)
+                .reason("신고사유")
+                .reporter(Member.builder().id(1L).build())
+                .createdAt(createdAt)
+                .lastModifiedAt(createdAt)
+                .build();
+
+        // Act
+        ReportDto dto = mapper.toDto(entity);
+
+        // Assert
+        assertEquals(entity.getId(), dto.getReportId());
+        assertEquals(entity.getTarget(), dto.getTarget());
+        assertEquals(entity.getTargetId(), dto.getTargetId());
+        assertEquals(entity.getReason(), dto.getReason());
+        assertEquals(entity.getReporter().getId(), dto.getReporterId());
+        assertEquals(entity.getCreatedAt(), dto.getCreatedAt());
+        assertEquals(entity.getLastModifiedAt(), dto.getLastModifiedAt());
+    }
+
+}

--- a/src/test/java/com/honeypot/domain/report/ReportServiceTest.java
+++ b/src/test/java/com/honeypot/domain/report/ReportServiceTest.java
@@ -1,0 +1,125 @@
+package com.honeypot.domain.report;
+
+import com.honeypot.common.model.exceptions.ReportTargetNotFoundException;
+import com.honeypot.domain.comment.repository.CommentRepository;
+import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.post.entity.Post;
+import com.honeypot.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+class ReportServiceTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private ReportMapper reportMapper;
+
+    private ReportService reportService;
+
+    @BeforeEach
+    private void before() {
+        this.reportService = new ReportService(reportRepository, postRepository, commentRepository, reportMapper);
+    }
+
+    @Test
+    void upload() {
+        // Arrange
+        ReportTarget target = ReportTarget.POST;
+        Long targetId = 1L;
+        String reason = "사유";
+        Long reporterId = 2L;
+
+        ReportUploadRequest uploadRequest = ReportUploadRequest.builder()
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .reporterId(reporterId)
+                .build();
+
+        Report toEntity = Report.builder()
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .reporter(Member.builder().id(reporterId).build())
+                .build();
+
+        LocalDateTime createdAt = LocalDateTime.now();
+        Report uploaded = Report.builder()
+                .id(1L)
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .reporter(Member.builder().id(reporterId).build())
+                .createdAt(createdAt)
+                .lastModifiedAt(createdAt)
+                .build();
+
+        ReportDto expected = ReportDto.builder()
+                .reportId(1L)
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .reporterId(reporterId)
+                .createdAt(createdAt)
+                .lastModifiedAt(createdAt)
+                .build();
+
+        when(postRepository.findById(targetId)).thenReturn(Optional.of(Post.builder().build()));
+        when(reportMapper.toEntity(uploadRequest)).thenReturn(toEntity);
+        when(reportRepository.save(toEntity)).thenReturn(uploaded);
+        when(reportMapper.toDto(uploaded)).thenReturn(expected);
+
+        // Act
+        ReportDto result = reportService.upload(uploadRequest);
+
+        // Assert
+        verify(commentRepository, never()).findById(targetId);
+        verify(postRepository, times(1)).findById(targetId);
+        verify(reportRepository, times(1)).save(toEntity);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void upload_ReportTargetNotFoundException() {
+        // Arrange
+        ReportTarget target = ReportTarget.POST;
+        Long targetId = 1L;
+        String reason = "사유";
+        Long reporterId = 2L;
+
+        ReportUploadRequest uploadRequest = ReportUploadRequest.builder()
+                .target(target)
+                .targetId(targetId)
+                .reason(reason)
+                .reporterId(reporterId)
+                .build();
+
+        when(postRepository.findById(targetId)).thenThrow(new ReportTargetNotFoundException(target, targetId));
+
+        // Act & Assert
+        assertThrows(ReportTargetNotFoundException.class, () -> {
+            reportService.upload(uploadRequest);
+        });
+    }
+
+}


### PR DESCRIPTION
### What's Changed?
- `post` ↔ `file` 양방향 연관관계 매핑 및 cascade 옵션 설정을 통한 외래키 제약조건 오류 수정 #81 
- 토큰 재발급 API 보완 #82 
- 신고하기 API 추가 #84 
- 내가 쓴 공동구매 게시글 전체 개수 쿼리 버그 수정 #86 
- 검색 키워드 최소 글자수 정책 변경 #88 
- 회원탈퇴, 토큰 재발급 실패 시 Refresh token Cookie 강제 만료 #90

### Related Issue
- resolved: #77
- resolved: #78
- resolved: #83
- resolved: #85
- resolved: #87
- resolved: #89

### Versioning
- version bump from **0.0.10** to **1.0.0**