### PR TITLE
Feature/member domain test coverage

### DIFF
--- a/src/test/java/com/honeypot/domain/member/api/MyPageApiTest.java
+++ b/src/test/java/com/honeypot/domain/member/api/MyPageApiTest.java
@@ -1,0 +1,111 @@
+package com.honeypot.domain.member.api;
+
+import com.honeypot.common.utils.SecurityUtils;
+import com.honeypot.domain.auth.service.contracts.AuthTokenManagerService;
+import com.honeypot.domain.post.dto.NormalPostDto;
+import com.honeypot.domain.post.entity.enums.PostType;
+import com.honeypot.domain.post.service.NormalPostService;
+import com.honeypot.domain.post.service.PostCrudServiceFactory;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MyPageApi.class)
+@ActiveProfiles("test")
+@MockBean(classes = {JpaMetamodelMappingContext.class, AuthTokenManagerService.class})
+@ExtendWith(MockitoExtension.class)
+class MyPageApiTest {
+
+    @MockBean
+    private PostCrudServiceFactory postCrudServiceFactory;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static MockedStatic<SecurityUtils> mockStatic;
+
+    @BeforeAll
+    public static void setup() {
+        mockStatic = mockStatic(SecurityUtils.class);
+    }
+
+    @AfterAll
+    public static void teardown() {
+        mockStatic.close();
+    }
+
+    @Test
+    void pageList_NormalPost_200_OK() throws Exception {
+        // Arrange
+        Long memberId = 1L;
+
+        int page = 0;
+        int size = 10;
+        int totalCount = 30;
+
+        String sortProperty = "createdAt";
+        String sortDirection = "desc";
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc(sortProperty)));
+        PostType postType = PostType.NORMAL;
+
+        List<NormalPostDto> list = createNormalPosts(page, size, totalCount);
+        Page<NormalPostDto> pageResult = new PageImpl<>(list, pageable, totalCount);
+
+        NormalPostService service = mock(NormalPostService.class);
+        when(SecurityUtils.getCurrentMemberId()).thenReturn(Optional.of(memberId));
+        when(postCrudServiceFactory.getService(postType)).thenReturn(service);
+        when(service.pageListByMemberId(pageable, memberId)).thenReturn(pageResult);
+
+        // Act
+        ResultActions actions = mockMvc.perform(get("/api/members/posts")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer token")
+                .queryParam("postType", postType.name())
+                .queryParam("page", String.valueOf(page))
+                .queryParam("size", String.valueOf(size))
+                .queryParam("sort", sortProperty + "," + sortDirection)
+        );
+
+        // Assert
+        actions.andExpect(status().isOk()).andDo(print());
+    }
+
+    private List<NormalPostDto> createNormalPosts(int page, int size, int totalCount) {
+        int start = page * size;
+        int end = (page + 1) * size;
+        end = Math.min(end, totalCount);
+
+        List<NormalPostDto> result = new ArrayList<>();
+        for (int i = start; i < end; i++) {
+            NormalPostDto dto = NormalPostDto.builder()
+                    .postId(i + 1L)
+                    .build();
+            result.add(dto);
+        }
+
+        return result;
+    }
+
+}

--- a/src/test/java/com/honeypot/domain/member/service/MemberFindServiceTest.java
+++ b/src/test/java/com/honeypot/domain/member/service/MemberFindServiceTest.java
@@ -1,0 +1,59 @@
+package com.honeypot.domain.member.service;
+
+import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+class MemberFindServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private MemberFindService memberFindService;
+
+    @BeforeEach
+    private void before() {
+        this.memberFindService = new MemberFindService(memberRepository);
+    }
+
+    @Test
+    void findById_MemberFound() {
+        // Arrange
+        Long id = 1L;
+        Member member = mock(Member.class);
+        when(memberRepository.findById(id)).thenReturn(Optional.of(member));
+
+        // Act
+        Optional<Member> result = memberFindService.findById(id);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(member, result.get());
+    }
+
+    @Test
+    void findById_MemberNotFound() {
+        // Arrange
+        Long id = 1L;
+        when(memberRepository.findById(id)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Member> result = memberFindService.findById(id);
+
+        // Assert
+        assertFalse(result.isPresent());
+    }
+
+}

--- a/src/test/java/com/honeypot/domain/member/service/MemberSignupServiceTest.java
+++ b/src/test/java/com/honeypot/domain/member/service/MemberSignupServiceTest.java
@@ -1,0 +1,101 @@
+package com.honeypot.domain.member.service;
+
+import com.honeypot.domain.auth.entity.AuthProvider;
+import com.honeypot.domain.auth.entity.enums.AuthProviderType;
+import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.member.entity.enums.Gender;
+import com.honeypot.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+class MemberSignupServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private MemberSignupService memberSignupService;
+
+    @BeforeEach
+    private void before() {
+        this.memberSignupService = new MemberSignupService(memberRepository);
+    }
+
+    @Test
+    void signup() {
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
+        Timestamp timestamp = new Timestamp(1237129848L);
+        Member created = Member.builder()
+                .id(1L)
+                .nickname("헤리움" + timestamp.getTime())
+                .ageRange("20-30")
+                .birthday("0404")
+                .email("example@gmail.com")
+                .gender(Gender.MALE)
+                .isWithdrawal(false)
+                .createdAt(now)
+                .lastModifiedAt(now)
+                .build();
+
+        when(memberRepository.save(any(Member.class))).thenReturn(created);
+
+        // Act
+        Member result = memberSignupService.signup();
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(created, result);
+    }
+
+    @Test
+    void signupWithOAuth() {
+        // Arrange
+        String providerMemberId = "1238123321";
+        AuthProviderType providerType = AuthProviderType.KAKAO;
+        LocalDateTime oAuthConnectDate = LocalDateTime.now();
+
+        LocalDateTime now = LocalDateTime.now();
+        Timestamp timestamp = new Timestamp(1237129848L);
+        Member created = Member.builder()
+                .id(1L)
+                .nickname("헤리움" + timestamp.getTime())
+                .ageRange("20-30")
+                .birthday("0404")
+                .email("example@gmail.com")
+                .gender(Gender.MALE)
+                .isWithdrawal(false)
+                .createdAt(now)
+                .lastModifiedAt(now)
+                .authProvider(AuthProvider.builder()
+                        .providerMemberId(providerMemberId)
+                        .providerType(providerType)
+                        .connectDate(oAuthConnectDate)
+                        .createdAt(now)
+                        .lastModifiedAt(now)
+                        .build())
+                .build();
+
+        when(memberRepository.save(any(Member.class))).thenReturn(created);
+
+        // Act
+        Member result = memberSignupService.signupWithOAuth(providerMemberId, providerType, oAuthConnectDate);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(created, result);
+    }
+
+}


### PR DESCRIPTION
### What's Changed?
- `member` 도메인 `api`, `service` Layer 테스트 커버리지 향상

| Class, % | Method, % | Line, % |
| - | - | - |
| 89.0% (374/420) | 70.0% (1120/1588) | 71.0% (3508/4898) |

![image](https://user-images.githubusercontent.com/61186671/185603813-1cd09f46-d8a7-4e88-96af-5a42d0e057c5.png)
![image](https://user-images.githubusercontent.com/61186671/185603861-4ca1f877-bd7d-4196-866c-0e11399eee05.png)


### Related Issue
- #92 