### PR TITLE
Feature/notification send data

### DIFF
--- a/src/main/java/com/honeypot/domain/comment/service/CommentService.java
+++ b/src/main/java/com/honeypot/domain/comment/service/CommentService.java
@@ -9,6 +9,9 @@ import com.honeypot.domain.comment.mapper.CommentMapper;
 import com.honeypot.domain.comment.repository.CommentRepository;
 import com.honeypot.domain.member.entity.Member;
 import com.honeypot.domain.member.service.MemberFindService;
+import com.honeypot.domain.notification.dto.NotificationData;
+import com.honeypot.domain.notification.dto.CommentNotificationResource;
+import com.honeypot.domain.notification.dto.PostNotificationResource;
 import com.honeypot.domain.notification.entity.enums.NotificationType;
 import com.honeypot.domain.notification.service.NotificationSendService;
 import com.honeypot.domain.post.entity.Post;
@@ -80,7 +83,23 @@ public class CommentService {
 
         // Async tasks
         if (!request.getWriterId().equals(post.getWriter().getId())) {
-            notificationSendService.send(post.getWriter().getId(), NotificationType.COMMENT_TO_MY_POST);
+            CommentNotificationResource resource = CommentNotificationResource.builder()
+                    .postResource(PostNotificationResource.builder()
+                            .id(post.getId())
+                            .type(post.getType())
+                            .writer(post.getWriter().getNickname())
+                            .build())
+                    .commentId(result.getCommentId())
+                    .commenter(result.getWriter().getNickname())
+                    .build();
+
+            notificationSendService.send(
+                    post.getWriter().getId(),
+                    NotificationData.<CommentNotificationResource>builder()
+                            .type(NotificationType.COMMENT_TO_MY_POST)
+                            .resource(resource)
+                            .build()
+            );
         }
 
         return result;

--- a/src/main/java/com/honeypot/domain/notification/dto/CommentNotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/CommentNotificationResource.java
@@ -1,5 +1,6 @@
 package com.honeypot.domain.notification.dto;
 
+import com.google.common.base.Objects;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,5 +13,20 @@ public class CommentNotificationResource extends NotificationResource {
     private final Long commentId;
 
     private final String commenter;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CommentNotificationResource that = (CommentNotificationResource) o;
+        return Objects.equal(postResource, that.postResource)
+                && Objects.equal(commentId, that.commentId)
+                && Objects.equal(commenter, that.commenter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(postResource, commentId, commenter);
+    }
 
 }

--- a/src/main/java/com/honeypot/domain/notification/dto/CommentNotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/CommentNotificationResource.java
@@ -1,0 +1,16 @@
+package com.honeypot.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CommentNotificationResource extends NotificationResource {
+
+    private final PostNotificationResource postResource;
+
+    private final Long commentId;
+
+    private final String commenter;
+
+}

--- a/src/main/java/com/honeypot/domain/notification/dto/NotificationData.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/NotificationData.java
@@ -1,5 +1,6 @@
 package com.honeypot.domain.notification.dto;
 
+import com.google.common.base.Objects;
 import com.honeypot.domain.notification.entity.enums.NotificationType;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,5 +12,18 @@ public class NotificationData<T extends NotificationResource> {
     private NotificationType type;
 
     private T resource;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NotificationData<?> that = (NotificationData<?>) o;
+        return type == that.type && Objects.equal(resource, that.resource);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(type, resource);
+    }
 
 }

--- a/src/main/java/com/honeypot/domain/notification/dto/NotificationData.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/NotificationData.java
@@ -1,0 +1,15 @@
+package com.honeypot.domain.notification.dto;
+
+import com.honeypot.domain.notification.entity.enums.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class NotificationData<T extends NotificationResource> {
+
+    private NotificationType type;
+
+    private T resource;
+
+}

--- a/src/main/java/com/honeypot/domain/notification/dto/NotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/NotificationResource.java
@@ -1,0 +1,5 @@
+package com.honeypot.domain.notification.dto;
+
+public abstract class NotificationResource {
+
+}

--- a/src/main/java/com/honeypot/domain/notification/dto/PostNotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/PostNotificationResource.java
@@ -1,0 +1,17 @@
+package com.honeypot.domain.notification.dto;
+
+import com.honeypot.domain.post.entity.enums.PostType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PostNotificationResource extends NotificationResource {
+
+    private final Long id;
+
+    private final PostType type;
+
+    private final String writer;
+
+}

--- a/src/main/java/com/honeypot/domain/notification/dto/PostNotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/PostNotificationResource.java
@@ -1,5 +1,6 @@
 package com.honeypot.domain.notification.dto;
 
+import com.google.common.base.Objects;
 import com.honeypot.domain.post.entity.enums.PostType;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,5 +14,20 @@ public class PostNotificationResource extends NotificationResource {
     private final PostType type;
 
     private final String writer;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PostNotificationResource that = (PostNotificationResource) o;
+        return Objects.equal(id, that.id)
+                && type == that.type
+                && Objects.equal(writer, that.writer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, type, writer);
+    }
 
 }

--- a/src/main/java/com/honeypot/domain/notification/dto/ReactionNotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/ReactionNotificationResource.java
@@ -1,5 +1,6 @@
 package com.honeypot.domain.notification.dto;
 
+import com.google.common.base.Objects;
 import com.honeypot.domain.reaction.entity.enums.ReactionType;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,5 +14,20 @@ public class ReactionNotificationResource extends NotificationResource {
     private final ReactionType reactionType;
 
     private final String reactor;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReactionNotificationResource that = (ReactionNotificationResource) o;
+        return Objects.equal(postResource, that.postResource)
+                && reactionType == that.reactionType
+                && Objects.equal(reactor, that.reactor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(postResource, reactionType, reactor);
+    }
 
 }

--- a/src/main/java/com/honeypot/domain/notification/dto/ReactionNotificationResource.java
+++ b/src/main/java/com/honeypot/domain/notification/dto/ReactionNotificationResource.java
@@ -1,0 +1,17 @@
+package com.honeypot.domain.notification.dto;
+
+import com.honeypot.domain.reaction.entity.enums.ReactionType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ReactionNotificationResource extends NotificationResource {
+
+    private final PostNotificationResource postResource;
+
+    private final ReactionType reactionType;
+
+    private final String reactor;
+
+}

--- a/src/main/java/com/honeypot/domain/post/entity/Post.java
+++ b/src/main/java/com/honeypot/domain/post/entity/Post.java
@@ -4,6 +4,7 @@ import com.honeypot.common.entity.BaseTimeEntity;
 import com.honeypot.domain.comment.entity.Comment;
 import com.honeypot.domain.file.File;
 import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.post.entity.enums.PostType;
 import com.honeypot.domain.reaction.entity.CommentReaction;
 import com.honeypot.domain.reaction.entity.PostReaction;
 import lombok.Builder;
@@ -59,6 +60,7 @@ public class Post extends BaseTimeEntity {
     private List<File> attachedFiles = new ArrayList<>();
 
     @Column(insertable = false, updatable = false)
-    private String type;
+    @Enumerated(EnumType.STRING)
+    private PostType type;
 
 }

--- a/src/main/java/com/honeypot/domain/post/repository/GroupBuyingPostQuerydslRepository.java
+++ b/src/main/java/com/honeypot/domain/post/repository/GroupBuyingPostQuerydslRepository.java
@@ -53,7 +53,7 @@ public class GroupBuyingPostQuerydslRepository {
         long totalCount = jpaQueryFactory
                 .select(post.id)
                 .from(post)
-                .where(post.type.eq(PostType.GROUP_BUYING.name()))
+                .where(post.type.eq(PostType.GROUP_BUYING))
                 .fetch()
                 .size();
 
@@ -79,7 +79,7 @@ public class GroupBuyingPostQuerydslRepository {
                 .from(post)
                 .innerJoin(member).on(post.writer.id.eq(member.id))
                 .where(member.id.eq(memberId)
-                        .and(post.type.eq(PostType.GROUP_BUYING.name()))
+                        .and(post.type.eq(PostType.GROUP_BUYING))
                 )
                 .fetch()
                 .size();

--- a/src/main/java/com/honeypot/domain/post/repository/NormalPostQuerydslRepository.java
+++ b/src/main/java/com/honeypot/domain/post/repository/NormalPostQuerydslRepository.java
@@ -53,7 +53,7 @@ public class NormalPostQuerydslRepository {
         long totalCount = jpaQueryFactory
                 .select(post.id)
                 .from(post)
-                .where(post.type.eq(PostType.NORMAL.name()))
+                .where(post.type.eq(PostType.NORMAL))
                 .fetch()
                 .size();
 
@@ -79,7 +79,7 @@ public class NormalPostQuerydslRepository {
                 .from(post)
                 .innerJoin(member).on(post.writer.id.eq(member.id))
                 .where(member.id.eq(memberId)
-                        .and(post.type.eq(PostType.NORMAL.name()))
+                        .and(post.type.eq(PostType.NORMAL))
                 )
                 .fetch()
                 .size();

--- a/src/main/java/com/honeypot/domain/post/repository/UsedTradePostQuerydslRepository.java
+++ b/src/main/java/com/honeypot/domain/post/repository/UsedTradePostQuerydslRepository.java
@@ -53,7 +53,7 @@ public class UsedTradePostQuerydslRepository {
         long totalCount = jpaQueryFactory
                 .select(post.id)
                 .from(post)
-                .where(post.type.eq(PostType.USED_TRADE.name()))
+                .where(post.type.eq(PostType.USED_TRADE))
                 .fetch()
                 .size();
 
@@ -79,7 +79,7 @@ public class UsedTradePostQuerydslRepository {
                 .from(post)
                 .innerJoin(member).on(post.writer.id.eq(member.id))
                 .where(member.id.eq(memberId)
-                        .and(post.type.eq(PostType.USED_TRADE.name()))
+                        .and(post.type.eq(PostType.USED_TRADE))
                 )
                 .fetch()
                 .size();

--- a/src/main/java/com/honeypot/domain/search/PostSearchQuerydslRepository.java
+++ b/src/main/java/com/honeypot/domain/search/PostSearchQuerydslRepository.java
@@ -41,7 +41,7 @@ public class PostSearchQuerydslRepository {
                 .leftJoin(groupBuyingPost).on(post.id.eq(groupBuyingPost.id))
                 .leftJoin(file).on(post.id.eq(file.post.id))
                 .fetchJoin()
-                .where(post.type.eq(criteria.getPostType().name())
+                .where(post.type.eq(criteria.getPostType())
                         .and(post.title.containsIgnoreCase(criteria.getKeyword())
                                 .or(post.content.containsIgnoreCase(criteria.getKeyword()))
                         )
@@ -55,7 +55,7 @@ public class PostSearchQuerydslRepository {
         long totalCount = jpaQueryFactory
                 .select(post.id)
                 .from(post)
-                .where(post.type.eq(criteria.getPostType().name())
+                .where(post.type.eq(criteria.getPostType())
                         .and(post.title.containsIgnoreCase(criteria.getKeyword())
                                 .or(post.content.containsIgnoreCase(criteria.getKeyword()))
                         )

--- a/src/test/java/com/honeypot/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/honeypot/domain/comment/service/CommentServiceTest.java
@@ -6,8 +6,10 @@ import com.honeypot.domain.comment.entity.Comment;
 import com.honeypot.domain.comment.mapper.CommentMapper;
 import com.honeypot.domain.comment.repository.CommentRepository;
 import com.honeypot.domain.member.entity.Member;
-import com.honeypot.domain.member.repository.MemberRepository;
 import com.honeypot.domain.member.service.MemberFindService;
+import com.honeypot.domain.notification.dto.CommentNotificationResource;
+import com.honeypot.domain.notification.dto.NotificationData;
+import com.honeypot.domain.notification.dto.PostNotificationResource;
 import com.honeypot.domain.notification.entity.enums.NotificationType;
 import com.honeypot.domain.notification.service.NotificationSendService;
 import com.honeypot.domain.post.entity.Post;
@@ -84,7 +86,23 @@ class CommentServiceTest {
 
         // Assert
         assertEquals(expected, result);
-        verify(notificationSendService, never()).send(targetPost.getWriter().getId(), NotificationType.COMMENT_TO_MY_POST);
+        CommentNotificationResource resource = CommentNotificationResource.builder()
+                .postResource(PostNotificationResource.builder()
+                        .id(targetPost.getId())
+                        .type(targetPost.getType())
+                        .writer(targetPost.getWriter().getNickname())
+                        .build())
+                .commentId(result.getCommentId())
+                .commenter(result.getWriter().getNickname())
+                .build();
+
+        verify(notificationSendService, never()).send(
+                targetPost.getWriter().getId(),
+                NotificationData.<CommentNotificationResource>builder()
+                        .type(NotificationType.COMMENT_TO_MY_POST)
+                        .resource(resource)
+                        .build()
+        );
     }
 
     @Test
@@ -116,7 +134,23 @@ class CommentServiceTest {
 
         // Assert
         assertEquals(expected, result);
-        verify(notificationSendService, times(1)).send(targetPost.getWriter().getId(), NotificationType.COMMENT_TO_MY_POST);
+        CommentNotificationResource resource = CommentNotificationResource.builder()
+                .postResource(PostNotificationResource.builder()
+                        .id(targetPost.getId())
+                        .type(targetPost.getType())
+                        .writer(targetPost.getWriter().getNickname())
+                        .build())
+                .commentId(result.getCommentId())
+                .commenter(result.getWriter().getNickname())
+                .build();
+
+        verify(notificationSendService, times(1)).send(
+                targetPost.getWriter().getId(),
+                NotificationData.<CommentNotificationResource>builder()
+                        .type(NotificationType.COMMENT_TO_MY_POST)
+                        .resource(resource)
+                        .build()
+        );
     }
 
     private Post createPost(Long id, Member writer) {

--- a/src/test/java/com/honeypot/domain/notification/service/NotificationSendServiceTest.java
+++ b/src/test/java/com/honeypot/domain/notification/service/NotificationSendServiceTest.java
@@ -1,14 +1,21 @@
 package com.honeypot.domain.notification.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.honeypot.domain.member.entity.Member;
 import com.honeypot.domain.member.service.MemberFindService;
+import com.honeypot.domain.notification.dto.CommentNotificationResource;
+import com.honeypot.domain.notification.dto.NotificationData;
 import com.honeypot.domain.notification.dto.NotificationTokenDto;
+import com.honeypot.domain.notification.dto.PostNotificationResource;
 import com.honeypot.domain.notification.entity.Notification;
 import com.honeypot.domain.notification.entity.enums.NotificationType;
 import com.honeypot.domain.notification.repository.NotificationRepository;
+import com.honeypot.domain.post.entity.enums.PostType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -19,8 +26,8 @@ import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
-@SpringBootTest(classes = NotificationSendService.class)
 @ActiveProfiles(profiles = {"test", "fcm"})
+@SpringBootTest(classes = {NotificationSendService.class, ObjectMapper.class})
 class NotificationSendServiceTest {
 
     @MockBean
@@ -33,40 +40,16 @@ class NotificationSendServiceTest {
     private NotificationRepository notificationRepository;
 
     @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
     private NotificationSendService notificationSendService;
 
     @Test
     @Timeout(10)
-    void send_toSingleReceiver() {
+    void send_ToSingleMember() {
         // Arrange
-        String token = "f2JVeYJgpSuPx_2J4854lE:APA91bGL7lNvfZMR7_TQNXgbldxoyB11FuSoODvRggXywx4OUU7Zrg-b_1q3v5UDXwTtBi02CgHc6b9ZzF93FTHNXNpn8ewdxdhy5h8iG2gLy20y5mgj-x0yEfwx8iJ-zBDfcPQFMBae";
-
-        // Act
-        notificationSendService.send(token, NotificationType.LIKE_REACTION_TO_MY_POST);
-
-        // Assert
-        // await().atMost(10, SECONDS).until(() -> apiFuture.get() != null);
-    }
-
-    @Test
-    @Timeout(10)
-    void send_toMultiReceiver() {
-        // Arrange
-        String token = "f2JVeYJgpSuPx_2J4854lE:APA91bGL7lNvfZMR7_TQNXgbldxoyB11FuSoODvRggXywx4OUU7Zrg-b_1q3v5UDXwTtBi02CgHc6b9ZzF93FTHNXNpn8ewdxdhy5h8iG2gLy20y5mgj-x0yEfwx8iJ-zBDfcPQFMBae";
-        String token2 = "eZPPh7NxWIiWMWSSRN1YLx:APA91bEnewBtElUaFzvlg_sz5f3B58o0KdGsVf3ONJH9ZnKjOhER59o__LPrGTy0qc99PuuwamX7EbT6yV7eAdiSLjiP-7YhF2XDrvYBFRBHD27V38Iqg81AGkh0d9t41Uy6QqsgJHma";
-        List<String> tokens = new ArrayList<>();
-        tokens.add(token);
-        tokens.add(token2);
-
-        // Act
-        notificationSendService.send(tokens, NotificationType.COMMENT_TO_MY_POST);
-    }
-
-    @Test
-    @Timeout(10)
-    void send_toSingleMember() {
-        // Arrange
-        Long memberId = 1L;
+        Long receiverId = 1L;
         NotificationType type = NotificationType.COMMENT_TO_MY_POST;
 
         String token = "f2JVeYJgpSuPx_2J4854lE:APA91bGL7lNvfZMR7_TQNXgbldxoyB11FuSoODvRggXywx4OUU7Zrg-b_1q3v5UDXwTtBi02CgHc6b9ZzF93FTHNXNpn8ewdxdhy5h8iG2gLy20y5mgj-x0yEfwx8iJ-zBDfcPQFMBae";
@@ -75,23 +58,34 @@ class NotificationSendServiceTest {
         tokens.add(NotificationTokenDto.builder().deviceToken(token).build());
         tokens.add(NotificationTokenDto.builder().deviceToken(token2).build());
 
-        Member member = Member.builder()
-                .id(memberId)
-                .nickname("nickname")
-                .build();
-
+        Member receiver = Member.builder().id(receiverId).nickname("nickname").build();
         Notification notification = Notification.builder()
-                .member(member)
+                .member(receiver)
                 .message(type.getBody())
                 .type(type)
                 .build();
 
-        when(memberFindService.findById(memberId)).thenReturn(Optional.of(member));
-        when(notificationTokenManageService.findByMemberId(memberId)).thenReturn(tokens);
+        when(memberFindService.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(notificationTokenManageService.findByMemberId(receiverId)).thenReturn(tokens);
         when(notificationRepository.save(notification)).thenReturn(any(Notification.class));
 
+        CommentNotificationResource resource = CommentNotificationResource.builder()
+                .postResource(PostNotificationResource.builder()
+                        .id(12433L)
+                        .type(PostType.NORMAL)
+                        .writer("postWriter")
+                        .build())
+                .commentId(2222L)
+                .commenter("commentWriter")
+                .build();
+
+        NotificationData<CommentNotificationResource> data = NotificationData.<CommentNotificationResource>builder()
+                .type(type)
+                .resource(resource)
+                .build();
+
         // Act
-        notificationSendService.send(memberId, type);
+        notificationSendService.send(receiverId, data);
     }
 
     @Test
@@ -101,9 +95,10 @@ class NotificationSendServiceTest {
         when(memberFindService.findById(memberId)).thenReturn(Optional.empty());
 
         // Act
-        notificationSendService.send(memberId, NotificationType.COMMENT_TO_MY_POST);
+        notificationSendService.send(memberId, any(NotificationData.class));
 
         // Assert
         verify(notificationRepository, never()).save(any(Notification.class));
     }
+
 }

--- a/src/test/java/com/honeypot/domain/reaction/service/PostReactionServiceTest.java
+++ b/src/test/java/com/honeypot/domain/reaction/service/PostReactionServiceTest.java
@@ -1,0 +1,207 @@
+package com.honeypot.domain.reaction.service;
+
+import com.honeypot.domain.member.entity.Member;
+import com.honeypot.domain.member.service.MemberFindService;
+import com.honeypot.domain.notification.dto.NotificationData;
+import com.honeypot.domain.notification.dto.PostNotificationResource;
+import com.honeypot.domain.notification.dto.ReactionNotificationResource;
+import com.honeypot.domain.notification.entity.enums.NotificationType;
+import com.honeypot.domain.notification.service.NotificationSendService;
+import com.honeypot.domain.post.entity.Post;
+import com.honeypot.domain.post.repository.PostRepository;
+import com.honeypot.domain.reaction.dto.ReactionDto;
+import com.honeypot.domain.reaction.dto.ReactionRequest;
+import com.honeypot.domain.reaction.entity.PostReaction;
+import com.honeypot.domain.reaction.entity.enums.ReactionTarget;
+import com.honeypot.domain.reaction.entity.enums.ReactionType;
+import com.honeypot.domain.reaction.mapper.ReactionMapper;
+import com.honeypot.domain.reaction.repository.PostReactionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+class PostReactionServiceTest {
+
+    private final ReactionMapper reactionMapper = Mappers.getMapper(ReactionMapper.class);
+
+    @Mock
+    private ReactionMapper reactionMapperMock;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private PostReactionRepository postReactionRepository;
+
+    @Mock
+    private MemberFindService memberFindService;
+
+    @Mock
+    private NotificationSendService notificationSendService;
+
+    private PostReactionService postReactionService;
+
+    @BeforeEach
+    public void before() {
+        postReactionService = new PostReactionService(
+                reactionMapperMock,
+                postRepository,
+                postReactionRepository,
+                memberFindService,
+                notificationSendService
+        );
+    }
+
+    @Test
+    @DisplayName("게시글 작성자와 리액터가 같으며, 푸시 알림 미전송 확인")
+    void save_PostWriterEqualsToReactor_NewReaction() {
+        // Arrange
+        Member reactor = Member.builder().id(999L).nickname("ReactorAndPostWriter").build();
+        Post targetPost = createPost(1231L, reactor);
+
+        ReactionRequest request = createPostLikeReactionRequest(reactor.getId(), targetPost.getId());
+        PostReaction created = createPostReactionFromReactionRequest(1213L, request);
+
+        ReactionDto expected = mockingPostReactionNotExists(request, reactor, targetPost, created);
+
+        // Act
+        ReactionDto result = postReactionService.save(request);
+
+        // Assert
+        assertEquals(expected, result);
+        verifyNotificationSend(targetPost, result, never());
+    }
+
+    @Test
+    @DisplayName("게시글 작성자와 리액터가 다르며 기존 리액션이 있을 경우, 푸시 알림 미전송 확인")
+    void save_PostWriterIsNotEqualsToReactor_ReactionAlreadyExists() {
+        // Arrange
+        Member reactor = Member.builder().id(999L).nickname("reactor").build();
+        Member postWriter = Member.builder().id(92L).nickname("postWriter").build();
+        Post targetPost = createPost(142L, postWriter);
+
+        ReactionRequest request = createPostLikeReactionRequest(reactor.getId(), targetPost.getId());
+        PostReaction existed = createPostReactionFromReactionRequest(5555L, request);
+
+        when(postRepository.findById(request.getTargetId())).thenReturn(Optional.of(targetPost));
+        when(postReactionRepository.findByReactorIdAndPostId(request.getReactorId(), targetPost.getId()))
+                .thenReturn(Optional.of(existed));
+
+        when(memberFindService.findById(existed.getReactor().getId())).thenReturn(Optional.of(reactor));
+
+        ReactionDto expected = reactionMapper.toDto(existed);
+        when(reactionMapperMock.toDto(existed)).thenReturn(expected);
+        expected.getReactor().setNickname(reactor.getNickname());
+
+        // Act
+        ReactionDto result = postReactionService.save(request);
+
+        // Assert
+        assertEquals(expected, result);
+        verifyNotificationSend(targetPost, result, never());
+    }
+
+    @Test
+    @DisplayName("게시글 작성자와 리액터가 다르며 기존 리액션이 없을 경우, 푸시 알림 전송 확인")
+    void save_PostWriterIsNotEqualsToReactor_NewReaction() {
+        // Arrange
+        Member reactor = Member.builder().id(999L).nickname("reactor").build();
+        Member postWriter = Member.builder().id(92L).nickname("postWriter").build();
+        Post targetPost = createPost(142L, postWriter);
+
+        ReactionRequest request = createPostLikeReactionRequest(reactor.getId(), targetPost.getId());
+        PostReaction created = createPostReactionFromReactionRequest(5555L, request);
+        ReactionDto expected = mockingPostReactionNotExists(request, reactor, targetPost, created);
+
+        // Act
+        ReactionDto result = postReactionService.save(request);
+
+        // Assert
+        assertEquals(expected, result);
+        verifyNotificationSend(targetPost, result, times(1));
+    }
+
+    private ReactionRequest createPostLikeReactionRequest(Long reactorId, Long postId) {
+        return ReactionRequest.builder()
+                .reactorId(reactorId)
+                .reactionType(ReactionType.LIKE)
+                .targetId(postId)
+                .targetType(String.valueOf(ReactionTarget.POST))
+                .build();
+    }
+
+    private Post createPost(Long id, Member writer) {
+        return Post.builder()
+                .id(id)
+                .writer(writer)
+                .build();
+    }
+
+    private PostReaction createPostReactionFromReactionRequest(Long id, ReactionRequest request) {
+        return PostReaction.builder()
+                .id(id)
+                .reactor(Member.builder().id(request.getReactorId()).build())
+                .reactionType(request.getReactionType())
+                .targetType(request.getTargetType())
+                .postId(request.getTargetId())
+                .build();
+    }
+
+    private ReactionDto mockingPostReactionNotExists(ReactionRequest request,
+                                                     Member reactor,
+                                                     Post targetPost,
+                                                     PostReaction created
+    ) {
+        when(postRepository.findById(request.getTargetId())).thenReturn(Optional.of(targetPost));
+        when(postReactionRepository.findByReactorIdAndPostId(request.getReactorId(), targetPost.getId()))
+                .thenReturn(Optional.empty());
+
+        PostReaction entity = reactionMapper.toPostReactionEntity(request);
+        when(reactionMapperMock.toPostReactionEntity(request)).thenReturn(entity);
+        when(postReactionRepository.save(entity)).thenReturn(created);
+        when(memberFindService.findById(created.getReactor().getId())).thenReturn(Optional.of(reactor));
+
+        ReactionDto expected = reactionMapper.toDto(created);
+        when(reactionMapperMock.toDto(created)).thenReturn(expected);
+        expected.getReactor().setNickname(reactor.getNickname());
+
+        return expected;
+    }
+
+    private void verifyNotificationSend(Post targetPost,
+                                        ReactionDto createdReaction,
+                                        VerificationMode verificationMode
+    ) {
+        ReactionNotificationResource resource = ReactionNotificationResource.builder()
+                .postResource(PostNotificationResource.builder()
+                        .id(targetPost.getId())
+                        .type(targetPost.getType())
+                        .writer(targetPost.getWriter().getNickname())
+                        .build())
+                .reactionType(createdReaction.getReactionType())
+                .reactor(createdReaction.getReactor().getNickname())
+                .build();
+
+        verify(notificationSendService, verificationMode).send(
+                targetPost.getWriter().getId(),
+                NotificationData.<ReactionNotificationResource>builder()
+                        .type(NotificationType.LIKE_REACTION_TO_MY_POST)
+                        .resource(resource)
+                        .build()
+        );
+    }
+
+}


### PR DESCRIPTION
### What's Changed?
- Push 알림 전송할 때 함께 전송할 관련 데이터 모델 설계
  - 추상 클래스 `NotificationResource`를 상속하는 여러 리소스와 알림 Type을 전송하도록 함
    - `PostNotificationResource`
    - `CommentNotificationResource`
    - `ReactionNotificationResource`
- `PostReactionService#save` 메서드 테스트 추가

### Related Issue
- resolved: #129 